### PR TITLE
feat: add cookie management options

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,6 +43,13 @@ extra:
       - accept
       - manage
       - reject
+    cookies:
+      analytics:
+        name: Google Analytics
+        checked: false
+      github:
+        name: Github
+        checked: false
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/FluentDo


### PR DESCRIPTION
Basic setup of defaults for material theme: https://squidfunk.github.io/mkdocs-material/setup/ensuring-data-privacy/#cookie-consent-custom-initial-state