### PR TITLE
ci: add mapping version for agent 1.2.3

### DIFF
--- a/docs/version-mapping.md
+++ b/docs/version-mapping.md
@@ -6,4 +6,5 @@ The following shows the underlying [OSS version of Fluent Bit](https://github.co
 
 |FluentDo Agent Version|OSS Version Base|
 |----------------------|----------------|
-| 25.7.1               | 4.0.3          |
+| 1.2.3 | 4.5.6 |
+| 25.7.1 | 4.0.3 |


### PR DESCRIPTION
Mapping version added for FluentDo agent 1.2.3:
- Agent Version: `1.2.3`
- OSS Version: `4.5.6`

This PR was created to update the version mapping in the documentation.

- Created by https://github.com/FluentDo/documentation/actions/runs/16238621761
- Auto-generated by create-pull-request: https://github.com/peter-evans/create-pull-request