### PR TITLE
release: add new mapping info

### DIFF
--- a/docs/version-mapping.md
+++ b/docs/version-mapping.md
@@ -6,4 +6,5 @@ The following shows the underlying [OSS version of Fluent Bit](https://github.co
 
 |FluentDo Agent Version|OSS Version Base|
 |----------------------|----------------|
+| 25.7.2 | 4.0.4 |
 | 25.7.1 | 4.0.3 |


### PR DESCRIPTION
Manual run for failure here: https://github.com/FluentDo/agent/actions/runs/16291858276/job/46004259135

```shell
export NEW_AGENT_VERSION=25.7.2
export NEW_OSS_VERSION=v4.0.4
./scripts/add-mapping-version.sh 
```

https://github.com/FluentDo/agent/pull/29 should fix it for future releases.