### PR TITLE
ci: add mapping version for agent 25.8.2

### DIFF
--- a/docs/version-mapping.md
+++ b/docs/version-mapping.md
@@ -6,6 +6,7 @@ The following shows the underlying [OSS version of Fluent Bit](https://github.co
 
 |FluentDo Agent Version|OSS Version Base|
 |----------------------|----------------|
+| 25.8.2 | 4.0.5 |
 | 25.7.4 | 4.0.5 |
 | 25.7.2 | 4.0.4 |
 | 25.7.1 | 4.0.3 |


### PR DESCRIPTION
Mapping version added for FluentDo agent 25.8.2:
- Agent Version: `25.8.2`
- OSS Version: `v4.0.5`

This PR was created to update the version mapping in the documentation.

- Created by https://github.com/FluentDo/agent/actions/runs/16967434753
- Auto-generated by create-pull-request: https://github.com/peter-evans/create-pull-request