### PR TITLE
fix: ensure new versions are added to security config

### DIFF
--- a/.github/workflows/call-add-mapping-version.yaml
+++ b/.github/workflows/call-add-mapping-version.yaml
@@ -55,6 +55,12 @@ jobs:
           NEW_OSS_VERSION: ${{ inputs.oss-version }}
           DRY_RUN: ${{ inputs.dry-run }}
 
+      - name: Debug info
+        run: |
+          git status
+          git diff
+        shell: bash
+
       - name: Create a PR with the update
         if: ${{ !inputs.dry-run }}
         id: cpr

--- a/.github/workflows/cron-run-scan.yaml
+++ b/.github/workflows/cron-run-scan.yaml
@@ -26,10 +26,9 @@ jobs:
           service_account: "terraform-infra@infrastructure-464010.iam.gserviceaccount.com"
 
       - id: get-secrets
-        name:
-          Get secrets from GCP Secret Manager
-          # This step retrieves secrets from GCP Secret Manager and sets them as outputs
-          # The secrets can then be accessed in subsequent steps using ${{ steps.get-secrets.outputs.<secret_name> }}
+        name: Get secrets from GCP Secret Manager
+        # This step retrieves secrets from GCP Secret Manager and sets them as outputs
+        # The secrets can then be accessed in subsequent steps using ${{ steps.get-secrets.outputs.<secret_name> }}
         uses: "google-github-actions/get-secretmanager-secrets@v2"
         with:
           secrets: |-

--- a/scripts/security/run-scans.sh
+++ b/scripts/security/run-scans.sh
@@ -13,7 +13,7 @@ done
 SCRIPT_DIR=$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )
 
 REPO_ROOT=${REPO_ROOT:-$SCRIPT_DIR/../..}
-CVE_DIR=${SOURCE_DIR:-$REPO_ROOT/docs/security}
+CVE_DIR=${CVE_DIR:-$REPO_ROOT/docs/security}
 TEMPLATE_DIR=${TEMPLATE_DIR:-$SCRIPT_DIR/templates}
 SCAN_FILE=${SCAN_FILE:-$SCRIPT_DIR/scan-config.json}
 

--- a/scripts/security/run-scans.sh
+++ b/scripts/security/run-scans.sh
@@ -107,7 +107,7 @@ for oss_version in "${OSS_VERSIONS[@]}"; do
     echo "Running syft for OSS version: $oss_version"
     if ! syft "ghcr.io/fluent/fluent-bit:$oss_version" --output json="$CVE_DIR/oss/syft-$oss_version.json" --output cyclonedx-json="$CVE_DIR/oss/cyclonedx-$oss_version.json" --output spdx-json="$CVE_DIR/oss/spdx-$oss_version.json"; then
         echo "Failed to run syft for OSS version: $oss_version, skipping grype scan."
-        rm -f "$CVE_DIR/oss/syft-$oss_version.json"
+        rm -f "$CVE_DIR/oss/*-$oss_version.json"
         continue
     fi
 


### PR DESCRIPTION
On agent release, ensure we add the version to the security scanning config to be included.

<!-- greptile_comment -->

## Greptile Summary

This PR enhances FluentDo's security automation pipeline to ensure that new agent releases are automatically included in vulnerability scanning. The key change extends the version mapping workflow to not only update documentation but also automatically add new versions to the security scan configuration and trigger immediate scans.

The changes address a critical gap where new versions were being documented but not automatically scanned for vulnerabilities until manual configuration updates. This automation ensures comprehensive security coverage as new releases become available.

The PR includes several supporting fixes: correcting a variable name typo in the security scanning script, improving cleanup behavior when scans fail, adding debug information to GitHub workflows for better troubleshooting, and fixing YAML formatting issues.

## Important Files Changed

<details>
<summary>Files Modified</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| `scripts/add-mapping-version.sh` | 4/5 | Enhanced to automatically update security scan config and trigger scans when new versions are added |
| `scripts/security/run-scans.sh` | 5/5 | Fixed variable name typo and improved cleanup behavior for failed scans |
| `.github/workflows/call-add-mapping-version.yaml` | 5/5 | Added debug output to help troubleshoot workflow execution |
| `.github/workflows/cron-run-scan.yaml` | 5/5 | Fixed YAML formatting issue in workflow step name |

</details>

## Sequence Diagram
```mermaid
sequenceDiagram
    participant User
    participant GitHub as "GitHub Actions"
    participant GCP as "GCP Secret Manager"
    participant DocRepo as "Documentation Repo"
    participant Registry as "Container Registry"
    participant Syft as "Syft Scanner"
    participant Grype as "Grype Scanner"

    User->>GitHub: "Trigger add-mapping-version workflow"
    GitHub->>GCP: "Authenticate with workload identity"
    GitHub->>GCP: "Get GitHub PAT secret"
    GitHub->>DocRepo: "Checkout documentation repository"
    GitHub->>DocRepo: "Execute add-mapping-version.sh script"
    
    Note over DocRepo: Update version-mapping.md
    DocRepo->>DocRepo: "Add new agent->OSS version mapping"
    
    Note over DocRepo: Update scan-config.json
    DocRepo->>DocRepo: "Add versions to agent_versions array"
    DocRepo->>DocRepo: "Add versions to oss_versions array"
    
    DocRepo->>DocRepo: "Execute security/run-scans.sh"
    
    loop For each agent version
        DocRepo->>Registry: "Pull agent container image"
        DocRepo->>Syft: "Generate SBOM for agent"
        Syft-->>DocRepo: "Return SBOM files (JSON, CycloneDX, SPDX)"
        DocRepo->>Grype: "Scan SBOM for vulnerabilities"
        Grype-->>DocRepo: "Generate vulnerability reports"
    end
    
    loop For each OSS version
        DocRepo->>Registry: "Pull OSS Fluent Bit image"
        DocRepo->>Syft: "Generate SBOM for OSS"
        Syft-->>DocRepo: "Return SBOM files (JSON, CycloneDX, SPDX)"
        DocRepo->>Grype: "Scan SBOM for vulnerabilities" 
        Grype-->>DocRepo: "Generate vulnerability reports"
    end
    
    DocRepo->>DocRepo: "Generate consolidated CVE index"
    GitHub->>GitHub: "Create pull request with updates"
    GitHub-->>User: "Return PR details"
```

<!-- /greptile_comment -->