### PR TITLE
feat: improve CVE output for agent 

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -18,8 +18,6 @@ We triage and resolve all CVEs reported against the FluentDo agent (and to some 
 
 We provide triaged CVE reports both as a [web page](./security/triaged.md) or a [VEX endpoint](./security/vex.json) for easy inclusion in security tooling deployed in your infrastructure.
 
---8<-- "docs/security/agent/grype-latest.md"
-
 ## Build and binary security
 
 ### Security Hardening Features

--- a/docs/security.md
+++ b/docs/security.md
@@ -18,6 +18,8 @@ We triage and resolve all CVEs reported against the FluentDo agent (and to some 
 
 We provide triaged CVE reports both as a [web page](./security/triaged.md) or a [VEX endpoint](./security/vex.json) for easy inclusion in security tooling deployed in your infrastructure.
 
+--8<-- "docs/security/agent/grype-latest.md"
+
 ## Build and binary security
 
 ### Security Hardening Features

--- a/docs/security.md
+++ b/docs/security.md
@@ -18,6 +18,14 @@ We triage and resolve all CVEs reported against the FluentDo agent (and to some 
 
 We provide triaged CVE reports both as a [web page](./security/triaged.md) or a [VEX endpoint](./security/vex.json) for easy inclusion in security tooling deployed in your infrastructure.
 
+The VEX endpoint can be downloaded and used like so:
+
+```shell
+curl -sSfLO https://fluent.do/security/vex.json
+trivy image fluent/fluent-bit:4.0.9 --vex vex.json
+grype fluent/fluent-bit:4.0.9 --vex vex.json
+```
+
 ## Build and binary security
 
 ### Security Hardening Features

--- a/docs/security.md
+++ b/docs/security.md
@@ -12,6 +12,12 @@ FluentDo provides an agent with the following security and compliance considerat
 - Full integration and regression testing in place
 - Hardened container images and best practice helm charts
 
+## CVEs
+
+We triage and resolve all CVEs reported against the FluentDo agent (and to some degree OSS too), please see [this page](./security/cves.md).
+
+We provide triaged CVE reports both as a [web page](./security/triaged.md) or a [VEX endpoint](./security/vex.json) for easy inclusion in security tooling deployed in your infrastructure.
+
 ## Build and binary security
 
 ### Security Hardening Features
@@ -78,8 +84,3 @@ To minimize attack surface and binary size, the following 17 plugins are **disab
 - `FLB_EXAMPLES` - Example binaries
 - `FLB_CHUNK_TRACE` - Debug chunk tracing
 
-## CVEs
-
-We triage and resolve all CVEs reported against the FluentDo agent (and to some degree OSS too), please see [this page](./security/cves.md).
-
-We provide triaged CVE reports both as a [web page](./security/triaged.md) or a [VEX endpoint](./security/vex.json) for easy inclusion in security tooling deployed in your infrastructure.

--- a/docs/security/agent/grype-25.7.1.json
+++ b/docs/security/agent/grype-25.7.1.json
@@ -7783,8 +7783,8 @@
       "output": [
         "json"
       ],
-      "file": "/home/pat/github/fluent-do/documentation/scripts/security/../../docs/security/agent/grype-25.7.1.json",
-      "pretty": false,
+      "file": "security/agent/grype-25.7.1.json",
+      "pretty": true,
       "distro": "",
       "add-cpes-if-none": false,
       "output-template-file": "",
@@ -7852,6 +7852,42 @@
           "vex-status": "",
           "vex-justification": "",
           "match-type": "exact-indirect-match"
+        },
+        {
+          "vulnerability": "",
+          "include-aliases": false,
+          "reason": "",
+          "namespace": "",
+          "fix-state": "",
+          "package": {
+            "name": "",
+            "version": "",
+            "language": "",
+            "type": "",
+            "location": "",
+            "upstream-name": ""
+          },
+          "vex-status": "not_affected",
+          "vex-justification": "",
+          "match-type": ""
+        },
+        {
+          "vulnerability": "",
+          "include-aliases": false,
+          "reason": "",
+          "namespace": "",
+          "fix-state": "",
+          "package": {
+            "name": "",
+            "version": "",
+            "language": "",
+            "type": "",
+            "location": "",
+            "upstream-name": ""
+          },
+          "vex-status": "fixed",
+          "vex-justification": "",
+          "match-type": ""
         }
       ],
       "exclude": [],
@@ -7908,7 +7944,9 @@
       },
       "name": "",
       "default-image-pull-source": "",
-      "vex-documents": [],
+      "vex-documents": [
+        "https://docs.fluent.do/security/vex.json"
+      ],
       "vex-add": [],
       "match-upstream-kernel-headers": false,
       "fix-channel": {
@@ -7919,7 +7957,7 @@
       },
       "timestamp": false,
       "db": {
-        "cache-dir": "/home/pat/.cache/grype/db",
+        "cache-dir": ".cache/grype/db",
         "update-url": "https://grype.anchore.io/databases",
         "ca-cert": "",
         "auto-update": true,
@@ -7943,7 +7981,7 @@
         "schemaVersion": "v6.1.0",
         "from": "https://grype.anchore.io/databases/v6/vulnerability-db_v6.1.0_2025-09-04T01:32:37Z_1756966195.tar.zst?checksum=sha256%3A1e86c44a864a6ababc85be32425c6c8d28c72ef0124e5d7ea582db6044545b4d",
         "built": "2025-09-04T06:09:55Z",
-        "path": "/home/pat/.cache/grype/db/6/vulnerability.db",
+        "path": ".cache/grype/db/6/vulnerability.db",
         "valid": true
       },
       "providers": {

--- a/docs/security/agent/grype-25.7.2.json
+++ b/docs/security/agent/grype-25.7.2.json
@@ -7783,8 +7783,8 @@
       "output": [
         "json"
       ],
-      "file": "/home/pat/github/fluent-do/documentation/scripts/security/../../docs/security/agent/grype-25.7.2.json",
-      "pretty": false,
+      "file": "security/agent/grype-25.7.2.json",
+      "pretty": true,
       "distro": "",
       "add-cpes-if-none": false,
       "output-template-file": "",
@@ -7852,6 +7852,42 @@
           "vex-status": "",
           "vex-justification": "",
           "match-type": "exact-indirect-match"
+        },
+        {
+          "vulnerability": "",
+          "include-aliases": false,
+          "reason": "",
+          "namespace": "",
+          "fix-state": "",
+          "package": {
+            "name": "",
+            "version": "",
+            "language": "",
+            "type": "",
+            "location": "",
+            "upstream-name": ""
+          },
+          "vex-status": "not_affected",
+          "vex-justification": "",
+          "match-type": ""
+        },
+        {
+          "vulnerability": "",
+          "include-aliases": false,
+          "reason": "",
+          "namespace": "",
+          "fix-state": "",
+          "package": {
+            "name": "",
+            "version": "",
+            "language": "",
+            "type": "",
+            "location": "",
+            "upstream-name": ""
+          },
+          "vex-status": "fixed",
+          "vex-justification": "",
+          "match-type": ""
         }
       ],
       "exclude": [],
@@ -7908,7 +7944,9 @@
       },
       "name": "",
       "default-image-pull-source": "",
-      "vex-documents": [],
+      "vex-documents": [
+        "https://docs.fluent.do/security/vex.json"
+      ],
       "vex-add": [],
       "match-upstream-kernel-headers": false,
       "fix-channel": {
@@ -7919,7 +7957,7 @@
       },
       "timestamp": false,
       "db": {
-        "cache-dir": "/home/pat/.cache/grype/db",
+        "cache-dir": ".cache/grype/db",
         "update-url": "https://grype.anchore.io/databases",
         "ca-cert": "",
         "auto-update": true,
@@ -7943,7 +7981,7 @@
         "schemaVersion": "v6.1.0",
         "from": "https://grype.anchore.io/databases/v6/vulnerability-db_v6.1.0_2025-09-04T01:32:37Z_1756966195.tar.zst?checksum=sha256%3A1e86c44a864a6ababc85be32425c6c8d28c72ef0124e5d7ea582db6044545b4d",
         "built": "2025-09-04T06:09:55Z",
-        "path": "/home/pat/.cache/grype/db/6/vulnerability.db",
+        "path": ".cache/grype/db/6/vulnerability.db",
         "valid": true
       },
       "providers": {

--- a/docs/security/agent/grype-25.7.4.json
+++ b/docs/security/agent/grype-25.7.4.json
@@ -7484,8 +7484,8 @@
       "output": [
         "json"
       ],
-      "file": "/home/pat/github/fluent-do/documentation/scripts/security/../../docs/security/agent/grype-25.7.4.json",
-      "pretty": false,
+      "file": "security/agent/grype-25.7.4.json",
+      "pretty": true,
       "distro": "",
       "add-cpes-if-none": false,
       "output-template-file": "",
@@ -7553,6 +7553,42 @@
           "vex-status": "",
           "vex-justification": "",
           "match-type": "exact-indirect-match"
+        },
+        {
+          "vulnerability": "",
+          "include-aliases": false,
+          "reason": "",
+          "namespace": "",
+          "fix-state": "",
+          "package": {
+            "name": "",
+            "version": "",
+            "language": "",
+            "type": "",
+            "location": "",
+            "upstream-name": ""
+          },
+          "vex-status": "not_affected",
+          "vex-justification": "",
+          "match-type": ""
+        },
+        {
+          "vulnerability": "",
+          "include-aliases": false,
+          "reason": "",
+          "namespace": "",
+          "fix-state": "",
+          "package": {
+            "name": "",
+            "version": "",
+            "language": "",
+            "type": "",
+            "location": "",
+            "upstream-name": ""
+          },
+          "vex-status": "fixed",
+          "vex-justification": "",
+          "match-type": ""
         }
       ],
       "exclude": [],
@@ -7609,7 +7645,9 @@
       },
       "name": "",
       "default-image-pull-source": "",
-      "vex-documents": [],
+      "vex-documents": [
+        "https://docs.fluent.do/security/vex.json"
+      ],
       "vex-add": [],
       "match-upstream-kernel-headers": false,
       "fix-channel": {
@@ -7620,7 +7658,7 @@
       },
       "timestamp": false,
       "db": {
-        "cache-dir": "/home/pat/.cache/grype/db",
+        "cache-dir": ".cache/grype/db",
         "update-url": "https://grype.anchore.io/databases",
         "ca-cert": "",
         "auto-update": true,
@@ -7644,7 +7682,7 @@
         "schemaVersion": "v6.1.0",
         "from": "https://grype.anchore.io/databases/v6/vulnerability-db_v6.1.0_2025-09-04T01:32:37Z_1756966195.tar.zst?checksum=sha256%3A1e86c44a864a6ababc85be32425c6c8d28c72ef0124e5d7ea582db6044545b4d",
         "built": "2025-09-04T06:09:55Z",
-        "path": "/home/pat/.cache/grype/db/6/vulnerability.db",
+        "path": ".cache/grype/db/6/vulnerability.db",
         "valid": true
       },
       "providers": {

--- a/docs/security/agent/grype-25.8.2.json
+++ b/docs/security/agent/grype-25.8.2.json
@@ -5889,8 +5889,8 @@
       "output": [
         "json"
       ],
-      "file": "/home/pat/github/fluent-do/documentation/scripts/security/../../docs/security/agent/grype-25.8.2.json",
-      "pretty": false,
+      "file": "security/agent/grype-25.8.2.json",
+      "pretty": true,
       "distro": "",
       "add-cpes-if-none": false,
       "output-template-file": "",
@@ -5958,6 +5958,42 @@
           "vex-status": "",
           "vex-justification": "",
           "match-type": "exact-indirect-match"
+        },
+        {
+          "vulnerability": "",
+          "include-aliases": false,
+          "reason": "",
+          "namespace": "",
+          "fix-state": "",
+          "package": {
+            "name": "",
+            "version": "",
+            "language": "",
+            "type": "",
+            "location": "",
+            "upstream-name": ""
+          },
+          "vex-status": "not_affected",
+          "vex-justification": "",
+          "match-type": ""
+        },
+        {
+          "vulnerability": "",
+          "include-aliases": false,
+          "reason": "",
+          "namespace": "",
+          "fix-state": "",
+          "package": {
+            "name": "",
+            "version": "",
+            "language": "",
+            "type": "",
+            "location": "",
+            "upstream-name": ""
+          },
+          "vex-status": "fixed",
+          "vex-justification": "",
+          "match-type": ""
         }
       ],
       "exclude": [],
@@ -6014,7 +6050,9 @@
       },
       "name": "",
       "default-image-pull-source": "",
-      "vex-documents": [],
+      "vex-documents": [
+        "https://docs.fluent.do/security/vex.json"
+      ],
       "vex-add": [],
       "match-upstream-kernel-headers": false,
       "fix-channel": {
@@ -6025,7 +6063,7 @@
       },
       "timestamp": false,
       "db": {
-        "cache-dir": "/home/pat/.cache/grype/db",
+        "cache-dir": ".cache/grype/db",
         "update-url": "https://grype.anchore.io/databases",
         "ca-cert": "",
         "auto-update": true,
@@ -6049,7 +6087,7 @@
         "schemaVersion": "v6.1.0",
         "from": "https://grype.anchore.io/databases/v6/vulnerability-db_v6.1.0_2025-09-04T01:32:37Z_1756966195.tar.zst?checksum=sha256%3A1e86c44a864a6ababc85be32425c6c8d28c72ef0124e5d7ea582db6044545b4d",
         "built": "2025-09-04T06:09:55Z",
-        "path": "/home/pat/.cache/grype/db/6/vulnerability.db",
+        "path": ".cache/grype/db/6/vulnerability.db",
         "valid": true
       },
       "providers": {

--- a/docs/security/agent/grype-25.8.4.json
+++ b/docs/security/agent/grype-25.8.4.json
@@ -5720,8 +5720,8 @@
       "output": [
         "json"
       ],
-      "file": "/home/pat/github/fluent-do/documentation/scripts/security/../../docs/security/agent/grype-25.8.4.json",
-      "pretty": false,
+      "file": "security/agent/grype-25.8.4.json",
+      "pretty": true,
       "distro": "",
       "add-cpes-if-none": false,
       "output-template-file": "",
@@ -5789,6 +5789,42 @@
           "vex-status": "",
           "vex-justification": "",
           "match-type": "exact-indirect-match"
+        },
+        {
+          "vulnerability": "",
+          "include-aliases": false,
+          "reason": "",
+          "namespace": "",
+          "fix-state": "",
+          "package": {
+            "name": "",
+            "version": "",
+            "language": "",
+            "type": "",
+            "location": "",
+            "upstream-name": ""
+          },
+          "vex-status": "not_affected",
+          "vex-justification": "",
+          "match-type": ""
+        },
+        {
+          "vulnerability": "",
+          "include-aliases": false,
+          "reason": "",
+          "namespace": "",
+          "fix-state": "",
+          "package": {
+            "name": "",
+            "version": "",
+            "language": "",
+            "type": "",
+            "location": "",
+            "upstream-name": ""
+          },
+          "vex-status": "fixed",
+          "vex-justification": "",
+          "match-type": ""
         }
       ],
       "exclude": [],
@@ -5845,7 +5881,9 @@
       },
       "name": "",
       "default-image-pull-source": "",
-      "vex-documents": [],
+      "vex-documents": [
+        "https://docs.fluent.do/security/vex.json"
+      ],
       "vex-add": [],
       "match-upstream-kernel-headers": false,
       "fix-channel": {
@@ -5856,7 +5894,7 @@
       },
       "timestamp": false,
       "db": {
-        "cache-dir": "/home/pat/.cache/grype/db",
+        "cache-dir": ".cache/grype/db",
         "update-url": "https://grype.anchore.io/databases",
         "ca-cert": "",
         "auto-update": true,
@@ -5880,7 +5918,7 @@
         "schemaVersion": "v6.1.0",
         "from": "https://grype.anchore.io/databases/v6/vulnerability-db_v6.1.0_2025-09-04T01:32:37Z_1756966195.tar.zst?checksum=sha256%3A1e86c44a864a6ababc85be32425c6c8d28c72ef0124e5d7ea582db6044545b4d",
         "built": "2025-09-04T06:09:55Z",
-        "path": "/home/pat/.cache/grype/db/6/vulnerability.db",
+        "path": ".cache/grype/db/6/vulnerability.db",
         "valid": true
       },
       "providers": {

--- a/docs/security/agent/grype-25.9.1.json
+++ b/docs/security/agent/grype-25.9.1.json
@@ -5595,8 +5595,8 @@
       "output": [
         "json"
       ],
-      "file": "/home/pat/github/fluent-do/documentation/scripts/security/../../docs/security/agent/grype-25.9.1.json",
-      "pretty": false,
+      "file": "security/agent/grype-25.9.1.json",
+      "pretty": true,
       "distro": "",
       "add-cpes-if-none": false,
       "output-template-file": "",
@@ -5664,6 +5664,42 @@
           "vex-status": "",
           "vex-justification": "",
           "match-type": "exact-indirect-match"
+        },
+        {
+          "vulnerability": "",
+          "include-aliases": false,
+          "reason": "",
+          "namespace": "",
+          "fix-state": "",
+          "package": {
+            "name": "",
+            "version": "",
+            "language": "",
+            "type": "",
+            "location": "",
+            "upstream-name": ""
+          },
+          "vex-status": "not_affected",
+          "vex-justification": "",
+          "match-type": ""
+        },
+        {
+          "vulnerability": "",
+          "include-aliases": false,
+          "reason": "",
+          "namespace": "",
+          "fix-state": "",
+          "package": {
+            "name": "",
+            "version": "",
+            "language": "",
+            "type": "",
+            "location": "",
+            "upstream-name": ""
+          },
+          "vex-status": "fixed",
+          "vex-justification": "",
+          "match-type": ""
         }
       ],
       "exclude": [],
@@ -5720,7 +5756,9 @@
       },
       "name": "",
       "default-image-pull-source": "",
-      "vex-documents": [],
+      "vex-documents": [
+        "https://docs.fluent.do/security/vex.json"
+      ],
       "vex-add": [],
       "match-upstream-kernel-headers": false,
       "fix-channel": {
@@ -5731,7 +5769,7 @@
       },
       "timestamp": false,
       "db": {
-        "cache-dir": "/home/pat/.cache/grype/db",
+        "cache-dir": ".cache/grype/db",
         "update-url": "https://grype.anchore.io/databases",
         "ca-cert": "",
         "auto-update": true,
@@ -5755,7 +5793,7 @@
         "schemaVersion": "v6.1.0",
         "from": "https://grype.anchore.io/databases/v6/vulnerability-db_v6.1.0_2025-09-04T01:32:37Z_1756966195.tar.zst?checksum=sha256%3A1e86c44a864a6ababc85be32425c6c8d28c72ef0124e5d7ea582db6044545b4d",
         "built": "2025-09-04T06:09:55Z",
-        "path": "/home/pat/.cache/grype/db/6/vulnerability.db",
+        "path": ".cache/grype/db/6/vulnerability.db",
         "valid": true
       },
       "providers": {

--- a/docs/security/agent/grype-latest.md
+++ b/docs/security/agent/grype-latest.md
@@ -1,0 +1,44 @@
+# Grype Vulnerabilities for ghcr.io/fluentdo/agent:25.9.1
+
+| Package | Version Installed | Vulnerability ID | Severity |
+| --- | --- | --- | --- |
+| gnutls | 3.8.3-6.el9 | [CVE-2025-32990](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-32990) | Medium |
+| gnutls | 3.8.3-6.el9 | [CVE-2025-6395](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-6395) | Medium |
+| gnutls | 3.8.3-6.el9 | [CVE-2025-32988](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-32988) | Medium |
+| systemd-libs | 252-51.el9_6.1 | [CVE-2025-4598](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-4598) | Medium |
+| gnutls | 3.8.3-6.el9 | [CVE-2025-32989](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-32989) | Medium |
+| coreutils-single | 8.32-39.el9 | [CVE-2025-5278](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-5278) | Medium |
+| libarchive | 3.5.3-6.el9_6 | [CVE-2023-30571](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-30571) | Medium |
+| libxml2 | 2.9.13-12.el9_6 | [CVE-2025-9714](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-9714) | Medium |
+| curl-minimal | 7.76.1-31.el9_6.1 | [CVE-2024-7264](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-7264) | Low |
+| libcurl-minimal | 7.76.1-31.el9_6.1 | [CVE-2024-7264](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-7264) | Low |
+| shadow-utils | 2:4.9-12.el9 | [CVE-2024-56433](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-56433) | Low |
+| curl-minimal | 7.76.1-31.el9_6.1 | [CVE-2024-9681](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-9681) | Low |
+| libcurl-minimal | 7.76.1-31.el9_6.1 | [CVE-2024-9681](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-9681) | Low |
+| curl-minimal | 7.76.1-31.el9_6.1 | [CVE-2024-11053](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-11053) | Low |
+| libcurl-minimal | 7.76.1-31.el9_6.1 | [CVE-2024-11053](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-11053) | Low |
+| libxml2 | 2.9.13-12.el9_6 | [CVE-2024-34459](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-34459) | Low |
+| glib2 | 2.68.4-16.el9_6.2 | [CVE-2023-32636](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-32636) | Low |
+| openssl | 1:3.2.2-6.el9_5.1 | [CVE-2024-41996](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-41996) | Low |
+| openssl-libs | 1:3.2.2-6.el9_5.1 | [CVE-2024-41996](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-41996) | Low |
+| libarchive | 3.5.3-6.el9_6 | [CVE-2025-1632](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-1632) | Low |
+| libxml2 | 2.9.13-12.el9_6 | [CVE-2023-45322](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-45322) | Low |
+| openssl | 1:3.2.2-6.el9_5.1 | [CVE-2024-13176](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-13176) | Low |
+| openssl-libs | 1:3.2.2-6.el9_5.1 | [CVE-2024-13176](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-13176) | Low |
+| pcre2 | 10.40-6.el9 | [CVE-2022-41409](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-41409) | Low |
+| pcre2-syntax | 10.40-6.el9 | [CVE-2022-41409](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-41409) | Low |
+| ncurses-base | 6.2-10.20210508.el9_6.2 | [CVE-2023-50495](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-50495) | Low |
+| ncurses-libs | 6.2-10.20210508.el9_6.2 | [CVE-2023-50495](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-50495) | Low |
+| libgcc | 11.5.0-5.el9_5 | [CVE-2022-27943](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-27943) | Low |
+| libstdc++ | 11.5.0-5.el9_5 | [CVE-2022-27943](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-27943) | Low |
+| glib2 | 2.68.4-16.el9_6.2 | [CVE-2025-3360](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-3360) | Low |
+| libxml2 | 2.9.13-12.el9_6 | [CVE-2025-27113](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-27113) | Low |
+| gawk | 5.1.0-6.el9 | [CVE-2023-4156](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-4156) | Low |
+| sqlite-libs | 3.34.1-8.el9_6 | [CVE-2024-0232](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-0232) | Low |
+| libarchive | 3.5.3-6.el9_6 | [CVE-2025-5918](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-5918) | Low |
+| libarchive | 3.5.3-6.el9_6 | [CVE-2025-5916](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-5916) | Low |
+| libxml2 | 2.9.13-12.el9_6 | [CVE-2025-6170](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-6170) | Low |
+| gnupg2 | 2.3.3-4.el9 | [CVE-2022-3219](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-3219) | Low |
+| gnupg2 | 2.3.3-4.el9 | [CVE-2025-30258](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-30258) | Low |
+| libarchive | 3.5.3-6.el9_6 | [CVE-2025-5915](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-5915) | Low |
+| libarchive | 3.5.3-6.el9_6 | [CVE-2025-5917](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-5917) | Low |

--- a/docs/security/cves.md
+++ b/docs/security/cves.md
@@ -4,6 +4,8 @@ This page hosts all known information about any security issues, mitigations and
 
 Please reach out to us at <info@fluent.do> directly for any specific concerns or queries.
 
+--8<-- "docs/security/agent/grype-latest.md"
+
 ## Agent Version: 25.7.1
 
 - [Grype Markdown Report](agent/grype-25.7.1.md)

--- a/docs/security/cves.md
+++ b/docs/security/cves.md
@@ -4,9 +4,13 @@ This page hosts all known information about any security issues, mitigations and
 
 Please reach out to us at <info@fluent.do> directly for any specific concerns or queries.
 
+--8<-- "docs/security/triaged.md"
+
 --8<-- "docs/security/agent/grype-latest.md"
 
-## Agent Version: 25.7.1
+## Previous and OSS versions
+
+### Agent Version: 25.7.1
 
 - [Grype Markdown Report](agent/grype-25.7.1.md)
 - [Grype JSON Report](agent/grype-25.7.1.json)
@@ -15,7 +19,7 @@ Please reach out to us at <info@fluent.do> directly for any specific concerns or
 - [CycloneDX JSON SBOM](agent/cyclonedx-25.7.1.cdx.json)
 - [SPDX JSON SBOM](agent/spdx-25.7.1.spdx.json)
 
-## Agent Version: 25.7.2
+### Agent Version: 25.7.2
 
 - [Grype Markdown Report](agent/grype-25.7.2.md)
 - [Grype JSON Report](agent/grype-25.7.2.json)
@@ -24,7 +28,7 @@ Please reach out to us at <info@fluent.do> directly for any specific concerns or
 - [CycloneDX JSON SBOM](agent/cyclonedx-25.7.2.cdx.json)
 - [SPDX JSON SBOM](agent/spdx-25.7.2.spdx.json)
 
-## Agent Version: 25.7.4
+### Agent Version: 25.7.4
 
 - [Grype Markdown Report](agent/grype-25.7.4.md)
 - [Grype JSON Report](agent/grype-25.7.4.json)
@@ -33,7 +37,7 @@ Please reach out to us at <info@fluent.do> directly for any specific concerns or
 - [CycloneDX JSON SBOM](agent/cyclonedx-25.7.4.cdx.json)
 - [SPDX JSON SBOM](agent/spdx-25.7.4.spdx.json)
 
-## Agent Version: 25.8.2
+### Agent Version: 25.8.2
 
 - [Grype Markdown Report](agent/grype-25.8.2.md)
 - [Grype JSON Report](agent/grype-25.8.2.json)
@@ -42,7 +46,7 @@ Please reach out to us at <info@fluent.do> directly for any specific concerns or
 - [CycloneDX JSON SBOM](agent/cyclonedx-25.8.2.cdx.json)
 - [SPDX JSON SBOM](agent/spdx-25.8.2.spdx.json)
 
-## Agent Version: 25.8.4
+### Agent Version: 25.8.4
 
 - [Grype Markdown Report](agent/grype-25.8.4.md)
 - [Grype JSON Report](agent/grype-25.8.4.json)
@@ -51,7 +55,7 @@ Please reach out to us at <info@fluent.do> directly for any specific concerns or
 - [CycloneDX JSON SBOM](agent/cyclonedx-25.8.4.cdx.json)
 - [SPDX JSON SBOM](agent/spdx-25.8.4.spdx.json)
 
-## Agent Version: 25.9.1
+### Agent Version: 25.9.1
 
 - [Grype Markdown Report](agent/grype-25.9.1.md)
 - [Grype JSON Report](agent/grype-25.9.1.json)
@@ -60,7 +64,7 @@ Please reach out to us at <info@fluent.do> directly for any specific concerns or
 - [CycloneDX JSON SBOM](agent/cyclonedx-25.9.1.cdx.json)
 - [SPDX JSON SBOM](agent/spdx-25.9.1.spdx.json)
 
-## Oss Version: 4.0.3
+### Oss Version: 4.0.3
 
 - [Grype Markdown Report](oss/grype-4.0.3.md)
 - [Grype JSON Report](oss/grype-4.0.3.json)
@@ -69,7 +73,7 @@ Please reach out to us at <info@fluent.do> directly for any specific concerns or
 - [CycloneDX JSON SBOM](oss/cyclonedx-4.0.3.cdx.json)
 - [SPDX JSON SBOM](oss/spdx-4.0.3.spdx.json)
 
-## Oss Version: 4.0.4
+### Oss Version: 4.0.4
 
 - [Grype Markdown Report](oss/grype-4.0.4.md)
 - [Grype JSON Report](oss/grype-4.0.4.json)
@@ -78,7 +82,7 @@ Please reach out to us at <info@fluent.do> directly for any specific concerns or
 - [CycloneDX JSON SBOM](oss/cyclonedx-4.0.4.cdx.json)
 - [SPDX JSON SBOM](oss/spdx-4.0.4.spdx.json)
 
-## Oss Version: 4.0.5
+### Oss Version: 4.0.5
 
 - [Grype Markdown Report](oss/grype-4.0.5.md)
 - [Grype JSON Report](oss/grype-4.0.5.json)
@@ -87,7 +91,7 @@ Please reach out to us at <info@fluent.do> directly for any specific concerns or
 - [CycloneDX JSON SBOM](oss/cyclonedx-4.0.5.cdx.json)
 - [SPDX JSON SBOM](oss/spdx-4.0.5.spdx.json)
 
-## Oss Version: 4.0.6
+### Oss Version: 4.0.6
 
 - [Grype Markdown Report](oss/grype-4.0.6.md)
 - [Grype JSON Report](oss/grype-4.0.6.json)
@@ -96,7 +100,7 @@ Please reach out to us at <info@fluent.do> directly for any specific concerns or
 - [CycloneDX JSON SBOM](oss/cyclonedx-4.0.6.cdx.json)
 - [SPDX JSON SBOM](oss/spdx-4.0.6.spdx.json)
 
-## Oss Version: 4.0.7
+### Oss Version: 4.0.7
 
 - [Grype Markdown Report](oss/grype-4.0.7.md)
 - [Grype JSON Report](oss/grype-4.0.7.json)
@@ -105,7 +109,7 @@ Please reach out to us at <info@fluent.do> directly for any specific concerns or
 - [CycloneDX JSON SBOM](oss/cyclonedx-4.0.7.cdx.json)
 - [SPDX JSON SBOM](oss/spdx-4.0.7.spdx.json)
 
-## Oss Version: 4.0.8
+### Oss Version: 4.0.8
 
 - [Grype Markdown Report](oss/grype-4.0.8.md)
 - [Grype JSON Report](oss/grype-4.0.8.json)
@@ -114,7 +118,7 @@ Please reach out to us at <info@fluent.do> directly for any specific concerns or
 - [CycloneDX JSON SBOM](oss/cyclonedx-4.0.8.cdx.json)
 - [SPDX JSON SBOM](oss/spdx-4.0.8.spdx.json)
 
-## Oss Version: 4.0.9
+### Oss Version: 4.0.9
 
 - [Grype Markdown Report](oss/grype-4.0.9.md)
 - [Grype JSON Report](oss/grype-4.0.9.json)

--- a/docs/security/oss/grype-4.0.3.json
+++ b/docs/security/oss/grype-4.0.3.json
@@ -7607,8 +7607,8 @@
       "output": [
         "json"
       ],
-      "file": "/home/pat/github/fluent-do/documentation/scripts/security/../../docs/security/oss/grype-4.0.3.json",
-      "pretty": false,
+      "file": "security/oss/grype-4.0.3.json",
+      "pretty": true,
       "distro": "",
       "add-cpes-if-none": false,
       "output-template-file": "",
@@ -7676,6 +7676,42 @@
           "vex-status": "",
           "vex-justification": "",
           "match-type": "exact-indirect-match"
+        },
+        {
+          "vulnerability": "",
+          "include-aliases": false,
+          "reason": "",
+          "namespace": "",
+          "fix-state": "",
+          "package": {
+            "name": "",
+            "version": "",
+            "language": "",
+            "type": "",
+            "location": "",
+            "upstream-name": ""
+          },
+          "vex-status": "not_affected",
+          "vex-justification": "",
+          "match-type": ""
+        },
+        {
+          "vulnerability": "",
+          "include-aliases": false,
+          "reason": "",
+          "namespace": "",
+          "fix-state": "",
+          "package": {
+            "name": "",
+            "version": "",
+            "language": "",
+            "type": "",
+            "location": "",
+            "upstream-name": ""
+          },
+          "vex-status": "fixed",
+          "vex-justification": "",
+          "match-type": ""
         }
       ],
       "exclude": [],
@@ -7732,7 +7768,9 @@
       },
       "name": "",
       "default-image-pull-source": "",
-      "vex-documents": [],
+      "vex-documents": [
+        "https://docs.fluent.do/security/vex.json"
+      ],
       "vex-add": [],
       "match-upstream-kernel-headers": false,
       "fix-channel": {
@@ -7743,7 +7781,7 @@
       },
       "timestamp": false,
       "db": {
-        "cache-dir": "/home/pat/.cache/grype/db",
+        "cache-dir": ".cache/grype/db",
         "update-url": "https://grype.anchore.io/databases",
         "ca-cert": "",
         "auto-update": true,
@@ -7767,7 +7805,7 @@
         "schemaVersion": "v6.1.0",
         "from": "https://grype.anchore.io/databases/v6/vulnerability-db_v6.1.0_2025-09-04T01:32:37Z_1756966195.tar.zst?checksum=sha256%3A1e86c44a864a6ababc85be32425c6c8d28c72ef0124e5d7ea582db6044545b4d",
         "built": "2025-09-04T06:09:55Z",
-        "path": "/home/pat/.cache/grype/db/6/vulnerability.db",
+        "path": ".cache/grype/db/6/vulnerability.db",
         "valid": true
       },
       "providers": {

--- a/docs/security/oss/grype-4.0.4.json
+++ b/docs/security/oss/grype-4.0.4.json
@@ -7607,8 +7607,8 @@
       "output": [
         "json"
       ],
-      "file": "/home/pat/github/fluent-do/documentation/scripts/security/../../docs/security/oss/grype-4.0.4.json",
-      "pretty": false,
+      "file": "security/oss/grype-4.0.4.json",
+      "pretty": true,
       "distro": "",
       "add-cpes-if-none": false,
       "output-template-file": "",
@@ -7676,6 +7676,42 @@
           "vex-status": "",
           "vex-justification": "",
           "match-type": "exact-indirect-match"
+        },
+        {
+          "vulnerability": "",
+          "include-aliases": false,
+          "reason": "",
+          "namespace": "",
+          "fix-state": "",
+          "package": {
+            "name": "",
+            "version": "",
+            "language": "",
+            "type": "",
+            "location": "",
+            "upstream-name": ""
+          },
+          "vex-status": "not_affected",
+          "vex-justification": "",
+          "match-type": ""
+        },
+        {
+          "vulnerability": "",
+          "include-aliases": false,
+          "reason": "",
+          "namespace": "",
+          "fix-state": "",
+          "package": {
+            "name": "",
+            "version": "",
+            "language": "",
+            "type": "",
+            "location": "",
+            "upstream-name": ""
+          },
+          "vex-status": "fixed",
+          "vex-justification": "",
+          "match-type": ""
         }
       ],
       "exclude": [],
@@ -7732,7 +7768,9 @@
       },
       "name": "",
       "default-image-pull-source": "",
-      "vex-documents": [],
+      "vex-documents": [
+        "https://docs.fluent.do/security/vex.json"
+      ],
       "vex-add": [],
       "match-upstream-kernel-headers": false,
       "fix-channel": {
@@ -7743,7 +7781,7 @@
       },
       "timestamp": false,
       "db": {
-        "cache-dir": "/home/pat/.cache/grype/db",
+        "cache-dir": ".cache/grype/db",
         "update-url": "https://grype.anchore.io/databases",
         "ca-cert": "",
         "auto-update": true,
@@ -7767,7 +7805,7 @@
         "schemaVersion": "v6.1.0",
         "from": "https://grype.anchore.io/databases/v6/vulnerability-db_v6.1.0_2025-09-04T01:32:37Z_1756966195.tar.zst?checksum=sha256%3A1e86c44a864a6ababc85be32425c6c8d28c72ef0124e5d7ea582db6044545b4d",
         "built": "2025-09-04T06:09:55Z",
-        "path": "/home/pat/.cache/grype/db/6/vulnerability.db",
+        "path": ".cache/grype/db/6/vulnerability.db",
         "valid": true
       },
       "providers": {

--- a/docs/security/oss/grype-4.0.5.json
+++ b/docs/security/oss/grype-4.0.5.json
@@ -7031,8 +7031,8 @@
       "output": [
         "json"
       ],
-      "file": "/home/pat/github/fluent-do/documentation/scripts/security/../../docs/security/oss/grype-4.0.5.json",
-      "pretty": false,
+      "file": "security/oss/grype-4.0.5.json",
+      "pretty": true,
       "distro": "",
       "add-cpes-if-none": false,
       "output-template-file": "",
@@ -7100,6 +7100,42 @@
           "vex-status": "",
           "vex-justification": "",
           "match-type": "exact-indirect-match"
+        },
+        {
+          "vulnerability": "",
+          "include-aliases": false,
+          "reason": "",
+          "namespace": "",
+          "fix-state": "",
+          "package": {
+            "name": "",
+            "version": "",
+            "language": "",
+            "type": "",
+            "location": "",
+            "upstream-name": ""
+          },
+          "vex-status": "not_affected",
+          "vex-justification": "",
+          "match-type": ""
+        },
+        {
+          "vulnerability": "",
+          "include-aliases": false,
+          "reason": "",
+          "namespace": "",
+          "fix-state": "",
+          "package": {
+            "name": "",
+            "version": "",
+            "language": "",
+            "type": "",
+            "location": "",
+            "upstream-name": ""
+          },
+          "vex-status": "fixed",
+          "vex-justification": "",
+          "match-type": ""
         }
       ],
       "exclude": [],
@@ -7156,7 +7192,9 @@
       },
       "name": "",
       "default-image-pull-source": "",
-      "vex-documents": [],
+      "vex-documents": [
+        "https://docs.fluent.do/security/vex.json"
+      ],
       "vex-add": [],
       "match-upstream-kernel-headers": false,
       "fix-channel": {
@@ -7167,7 +7205,7 @@
       },
       "timestamp": false,
       "db": {
-        "cache-dir": "/home/pat/.cache/grype/db",
+        "cache-dir": ".cache/grype/db",
         "update-url": "https://grype.anchore.io/databases",
         "ca-cert": "",
         "auto-update": true,
@@ -7191,7 +7229,7 @@
         "schemaVersion": "v6.1.0",
         "from": "https://grype.anchore.io/databases/v6/vulnerability-db_v6.1.0_2025-09-04T01:32:37Z_1756966195.tar.zst?checksum=sha256%3A1e86c44a864a6ababc85be32425c6c8d28c72ef0124e5d7ea582db6044545b4d",
         "built": "2025-09-04T06:09:55Z",
-        "path": "/home/pat/.cache/grype/db/6/vulnerability.db",
+        "path": ".cache/grype/db/6/vulnerability.db",
         "valid": true
       },
       "providers": {

--- a/docs/security/oss/grype-4.0.6.json
+++ b/docs/security/oss/grype-4.0.6.json
@@ -7031,8 +7031,8 @@
       "output": [
         "json"
       ],
-      "file": "/home/pat/github/fluent-do/documentation/scripts/security/../../docs/security/oss/grype-4.0.6.json",
-      "pretty": false,
+      "file": "security/oss/grype-4.0.6.json",
+      "pretty": true,
       "distro": "",
       "add-cpes-if-none": false,
       "output-template-file": "",
@@ -7100,6 +7100,42 @@
           "vex-status": "",
           "vex-justification": "",
           "match-type": "exact-indirect-match"
+        },
+        {
+          "vulnerability": "",
+          "include-aliases": false,
+          "reason": "",
+          "namespace": "",
+          "fix-state": "",
+          "package": {
+            "name": "",
+            "version": "",
+            "language": "",
+            "type": "",
+            "location": "",
+            "upstream-name": ""
+          },
+          "vex-status": "not_affected",
+          "vex-justification": "",
+          "match-type": ""
+        },
+        {
+          "vulnerability": "",
+          "include-aliases": false,
+          "reason": "",
+          "namespace": "",
+          "fix-state": "",
+          "package": {
+            "name": "",
+            "version": "",
+            "language": "",
+            "type": "",
+            "location": "",
+            "upstream-name": ""
+          },
+          "vex-status": "fixed",
+          "vex-justification": "",
+          "match-type": ""
         }
       ],
       "exclude": [],
@@ -7156,7 +7192,9 @@
       },
       "name": "",
       "default-image-pull-source": "",
-      "vex-documents": [],
+      "vex-documents": [
+        "https://docs.fluent.do/security/vex.json"
+      ],
       "vex-add": [],
       "match-upstream-kernel-headers": false,
       "fix-channel": {
@@ -7167,7 +7205,7 @@
       },
       "timestamp": false,
       "db": {
-        "cache-dir": "/home/pat/.cache/grype/db",
+        "cache-dir": ".cache/grype/db",
         "update-url": "https://grype.anchore.io/databases",
         "ca-cert": "",
         "auto-update": true,
@@ -7191,7 +7229,7 @@
         "schemaVersion": "v6.1.0",
         "from": "https://grype.anchore.io/databases/v6/vulnerability-db_v6.1.0_2025-09-04T01:32:37Z_1756966195.tar.zst?checksum=sha256%3A1e86c44a864a6ababc85be32425c6c8d28c72ef0124e5d7ea582db6044545b4d",
         "built": "2025-09-04T06:09:55Z",
-        "path": "/home/pat/.cache/grype/db/6/vulnerability.db",
+        "path": ".cache/grype/db/6/vulnerability.db",
         "valid": true
       },
       "providers": {

--- a/docs/security/oss/grype-4.0.7.json
+++ b/docs/security/oss/grype-4.0.7.json
@@ -7036,8 +7036,8 @@
       "output": [
         "json"
       ],
-      "file": "/home/pat/github/fluent-do/documentation/scripts/security/../../docs/security/oss/grype-4.0.7.json",
-      "pretty": false,
+      "file": "security/oss/grype-4.0.7.json",
+      "pretty": true,
       "distro": "",
       "add-cpes-if-none": false,
       "output-template-file": "",
@@ -7105,6 +7105,42 @@
           "vex-status": "",
           "vex-justification": "",
           "match-type": "exact-indirect-match"
+        },
+        {
+          "vulnerability": "",
+          "include-aliases": false,
+          "reason": "",
+          "namespace": "",
+          "fix-state": "",
+          "package": {
+            "name": "",
+            "version": "",
+            "language": "",
+            "type": "",
+            "location": "",
+            "upstream-name": ""
+          },
+          "vex-status": "not_affected",
+          "vex-justification": "",
+          "match-type": ""
+        },
+        {
+          "vulnerability": "",
+          "include-aliases": false,
+          "reason": "",
+          "namespace": "",
+          "fix-state": "",
+          "package": {
+            "name": "",
+            "version": "",
+            "language": "",
+            "type": "",
+            "location": "",
+            "upstream-name": ""
+          },
+          "vex-status": "fixed",
+          "vex-justification": "",
+          "match-type": ""
         }
       ],
       "exclude": [],
@@ -7161,7 +7197,9 @@
       },
       "name": "",
       "default-image-pull-source": "",
-      "vex-documents": [],
+      "vex-documents": [
+        "https://docs.fluent.do/security/vex.json"
+      ],
       "vex-add": [],
       "match-upstream-kernel-headers": false,
       "fix-channel": {
@@ -7172,7 +7210,7 @@
       },
       "timestamp": false,
       "db": {
-        "cache-dir": "/home/pat/.cache/grype/db",
+        "cache-dir": ".cache/grype/db",
         "update-url": "https://grype.anchore.io/databases",
         "ca-cert": "",
         "auto-update": true,
@@ -7196,7 +7234,7 @@
         "schemaVersion": "v6.1.0",
         "from": "https://grype.anchore.io/databases/v6/vulnerability-db_v6.1.0_2025-09-04T01:32:37Z_1756966195.tar.zst?checksum=sha256%3A1e86c44a864a6ababc85be32425c6c8d28c72ef0124e5d7ea582db6044545b4d",
         "built": "2025-09-04T06:09:55Z",
-        "path": "/home/pat/.cache/grype/db/6/vulnerability.db",
+        "path": ".cache/grype/db/6/vulnerability.db",
         "valid": true
       },
       "providers": {

--- a/docs/security/oss/grype-4.0.8.json
+++ b/docs/security/oss/grype-4.0.8.json
@@ -7036,8 +7036,8 @@
       "output": [
         "json"
       ],
-      "file": "/home/pat/github/fluent-do/documentation/scripts/security/../../docs/security/oss/grype-4.0.8.json",
-      "pretty": false,
+      "file": "security/oss/grype-4.0.8.json",
+      "pretty": true,
       "distro": "",
       "add-cpes-if-none": false,
       "output-template-file": "",
@@ -7105,6 +7105,42 @@
           "vex-status": "",
           "vex-justification": "",
           "match-type": "exact-indirect-match"
+        },
+        {
+          "vulnerability": "",
+          "include-aliases": false,
+          "reason": "",
+          "namespace": "",
+          "fix-state": "",
+          "package": {
+            "name": "",
+            "version": "",
+            "language": "",
+            "type": "",
+            "location": "",
+            "upstream-name": ""
+          },
+          "vex-status": "not_affected",
+          "vex-justification": "",
+          "match-type": ""
+        },
+        {
+          "vulnerability": "",
+          "include-aliases": false,
+          "reason": "",
+          "namespace": "",
+          "fix-state": "",
+          "package": {
+            "name": "",
+            "version": "",
+            "language": "",
+            "type": "",
+            "location": "",
+            "upstream-name": ""
+          },
+          "vex-status": "fixed",
+          "vex-justification": "",
+          "match-type": ""
         }
       ],
       "exclude": [],
@@ -7161,7 +7197,9 @@
       },
       "name": "",
       "default-image-pull-source": "",
-      "vex-documents": [],
+      "vex-documents": [
+        "https://docs.fluent.do/security/vex.json"
+      ],
       "vex-add": [],
       "match-upstream-kernel-headers": false,
       "fix-channel": {
@@ -7172,7 +7210,7 @@
       },
       "timestamp": false,
       "db": {
-        "cache-dir": "/home/pat/.cache/grype/db",
+        "cache-dir": ".cache/grype/db",
         "update-url": "https://grype.anchore.io/databases",
         "ca-cert": "",
         "auto-update": true,
@@ -7196,7 +7234,7 @@
         "schemaVersion": "v6.1.0",
         "from": "https://grype.anchore.io/databases/v6/vulnerability-db_v6.1.0_2025-09-04T01:32:37Z_1756966195.tar.zst?checksum=sha256%3A1e86c44a864a6ababc85be32425c6c8d28c72ef0124e5d7ea582db6044545b4d",
         "built": "2025-09-04T06:09:55Z",
-        "path": "/home/pat/.cache/grype/db/6/vulnerability.db",
+        "path": ".cache/grype/db/6/vulnerability.db",
         "valid": true
       },
       "providers": {

--- a/docs/security/oss/grype-4.0.9.json
+++ b/docs/security/oss/grype-4.0.9.json
@@ -7036,8 +7036,8 @@
       "output": [
         "json"
       ],
-      "file": "/home/pat/github/fluent-do/documentation/scripts/security/../../docs/security/oss/grype-4.0.9.json",
-      "pretty": false,
+      "file": "security/oss/grype-4.0.9.json",
+      "pretty": true,
       "distro": "",
       "add-cpes-if-none": false,
       "output-template-file": "",
@@ -7105,6 +7105,42 @@
           "vex-status": "",
           "vex-justification": "",
           "match-type": "exact-indirect-match"
+        },
+        {
+          "vulnerability": "",
+          "include-aliases": false,
+          "reason": "",
+          "namespace": "",
+          "fix-state": "",
+          "package": {
+            "name": "",
+            "version": "",
+            "language": "",
+            "type": "",
+            "location": "",
+            "upstream-name": ""
+          },
+          "vex-status": "not_affected",
+          "vex-justification": "",
+          "match-type": ""
+        },
+        {
+          "vulnerability": "",
+          "include-aliases": false,
+          "reason": "",
+          "namespace": "",
+          "fix-state": "",
+          "package": {
+            "name": "",
+            "version": "",
+            "language": "",
+            "type": "",
+            "location": "",
+            "upstream-name": ""
+          },
+          "vex-status": "fixed",
+          "vex-justification": "",
+          "match-type": ""
         }
       ],
       "exclude": [],
@@ -7161,7 +7197,9 @@
       },
       "name": "",
       "default-image-pull-source": "",
-      "vex-documents": [],
+      "vex-documents": [
+        "https://docs.fluent.do/security/vex.json"
+      ],
       "vex-add": [],
       "match-upstream-kernel-headers": false,
       "fix-channel": {
@@ -7172,7 +7210,7 @@
       },
       "timestamp": false,
       "db": {
-        "cache-dir": "/home/pat/.cache/grype/db",
+        "cache-dir": ".cache/grype/db",
         "update-url": "https://grype.anchore.io/databases",
         "ca-cert": "",
         "auto-update": true,
@@ -7196,7 +7234,7 @@
         "schemaVersion": "v6.1.0",
         "from": "https://grype.anchore.io/databases/v6/vulnerability-db_v6.1.0_2025-09-04T01:32:37Z_1756966195.tar.zst?checksum=sha256%3A1e86c44a864a6ababc85be32425c6c8d28c72ef0124e5d7ea582db6044545b4d",
         "built": "2025-09-04T06:09:55Z",
-        "path": "/home/pat/.cache/grype/db/6/vulnerability.db",
+        "path": ".cache/grype/db/6/vulnerability.db",
         "valid": true
       },
       "providers": {

--- a/docs/security/triaged/CVE-2023-2953/investigation.vex.json
+++ b/docs/security/triaged/CVE-2023-2953/investigation.vex.json
@@ -12,7 +12,7 @@
       "timestamp": "2025-09-05T11:58:04.888079756+01:00",
       "products": [
         {
-          "@id": "pkg:docker/fluent/fluent-bit:4.0.9"
+          "@id": "pkg:oci/fluent-bit"
         }
       ],
       "status": "under_investigation"

--- a/docs/security/triaged/CVE-2023-2953/triaged.vex.json
+++ b/docs/security/triaged/CVE-2023-2953/triaged.vex.json
@@ -12,11 +12,11 @@
       "timestamp": "2025-09-05T11:58:13.020338977+01:00",
       "products": [
         {
-          "@id": "pkg:docker/fluent/fluent-bit:4.0.9"
+          "@id": "pkg:oci/fluent-bit"
         }
       ],
       "status": "not_affected",
-      "justification": "inline_mitigations_already_exist",
+      "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "Fluent Bit does not use this component directly or in the way affected in the CVE."
     }
   ]

--- a/docs/security/triaged/CVE-2023-2953/vex.json
+++ b/docs/security/triaged/CVE-2023-2953/vex.json
@@ -12,7 +12,7 @@
       "timestamp": "2025-09-05T11:58:04.888079756+01:00",
       "products": [
         {
-          "@id": "pkg:docker/fluent/fluent-bit:4.0.9"
+          "@id": "pkg:oci/fluent-bit"
         }
       ],
       "status": "under_investigation"
@@ -24,7 +24,7 @@
       "timestamp": "2025-09-05T11:58:13.020338977+01:00",
       "products": [
         {
-          "@id": "pkg:docker/fluent/fluent-bit:4.0.9"
+          "@id": "pkg:oci/fluent-bit"
         }
       ],
       "status": "not_affected",

--- a/docs/security/triaged/README.md
+++ b/docs/security/triaged/README.md
@@ -13,7 +13,7 @@ Using CVE-2023-2953 as an example, we do the following:
 
     ```shell
     cd docs/security/triaged/CVE-2023-2953
-    vexctl create --product="pkg:docker/fluent/fluent-bit:4.0.9" \
+    vexctl create --product="pkg:oci/fluent-bit" \
                 --vuln="CVE-2023-2953" \
                 --status="under_investigation" \
                 --author="info@fluent.do" \
@@ -25,14 +25,16 @@ Using CVE-2023-2953 as an example, we do the following:
 
     ```shell
     cd docs/security/triaged/CVE-2023-2953
-    vexctl create --product="pkg:docker/fluent/fluent-bit:4.0.9" \
+    vexctl create --product="pkg:oci/fluent-bit" \
                 --vuln="CVE-2023-2953" \
                 --status="not_affected" \
-                --justification="inline_mitigations_already_exist" \
+                --justification="vulnerable_code_not_in_execute_path" \
                 --author="info@fluent.do" \
                 --impact-statement="Fluent Bit does not use this component directly or in the way affected in the CVE." \
                  | tee triaged.vex.json
     ```
+
+    Note that we use the `oci/fluent-bit` pURL which will target any image ending in `fluent-bit`, the full pURL spec lets you specify registry and other information: <https://github.com/package-url/purl-spec>.
 
     For justification you must use one of the expected values: <https://github.com/openvex/spec/blob/main/OPENVEX-SPEC.md#status-justifications>.
     The impact statement is freeform text and will be what we display for user-readable documentation so ensure it is well written and helpful for users.
@@ -51,9 +53,20 @@ The generation process will loop through all CVE directories and merge any VEX f
 cd docs/security/triaged/CVE-2023-2953
 vexctl merge --author="info@fluent.do" \
             investigation.vex.json \
-            triaged.vex.json
+            triaged.vex.json | tee vex.json
 ```
 
 From these we then create a top-level VEX feed/file of everything.
 
 Ensure all new files are added to Git.
+
+## Testing
+
+We can use the VEX document locally to run with Trivy or Grype:
+
+```shell
+trivy image fluent/fluent-bit:4.0.9 --vex docs/security/vex.json
+grype fluent/fluent-bit:4.0.9 --vex docs/security/vex.json
+```
+
+In each case, neither should show the presence of CVE-2023-2953.

--- a/docs/security/vex.json
+++ b/docs/security/vex.json
@@ -9,26 +9,14 @@
       "vulnerability": {
         "name": "CVE-2023-2953"
       },
-      "timestamp": "2025-09-05T11:58:04.888079756+01:00",
-      "products": [
-        {
-          "@id": "pkg:docker/fluent/fluent-bit:4.0.9"
-        }
-      ],
-      "status": "under_investigation"
-    },
-    {
-      "vulnerability": {
-        "name": "CVE-2023-2953"
-      },
       "timestamp": "2025-09-05T11:58:13.020338977+01:00",
       "products": [
         {
-          "@id": "pkg:docker/fluent/fluent-bit:4.0.9"
+          "@id": "pkg:oci/fluent-bit"
         }
       ],
       "status": "not_affected",
-      "justification": "inline_mitigations_already_exist",
+      "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "Fluent Bit does not use this component directly or in the way affected in the CVE."
     }
   ]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,6 +17,8 @@ plugins:
   - search
   - social
   - meta
+markdown_extensions:
+  - pymdownx.snippets
 
 theme:
   name: material

--- a/scripts/security/run-scans.sh
+++ b/scripts/security/run-scans.sh
@@ -64,6 +64,12 @@ cat <<EOF > "$CVE_DIR/cves.md"
 This page hosts all known information about any security issues, mitigations and triaged CVEs.
 
 Please reach out to us at <info@fluent.do> directly for any specific concerns or queries.
+
+--8<-- "docs/security/triaged.md"
+
+--8<-- "docs/security/agent/grype-latest.md"
+
+## Previous and OSS versions
 EOF
 
 function generateReports() {
@@ -110,7 +116,7 @@ function generateReports() {
     # Add to the index file
     {
     echo ""
-    echo "## $type_capitalised Version: $version"
+    echo "### $type_capitalised Version: $version"
     echo ""
     echo "- [Grype Markdown Report]($type/grype-$version.md)"
     echo "- [Grype JSON Report]($type/grype-$version.json)"

--- a/scripts/security/run-scans.sh
+++ b/scripts/security/run-scans.sh
@@ -124,6 +124,9 @@ function generateReports() {
 # Run grype for each Agent version
 for agent_version in "${AGENT_VERSIONS[@]}"; do
 	generateReports "$agent_version" "agent"
+	# We copy the agent grype report to a "latest" file for easy reference in the main security.md document
+	cp "$CVE_DIR/agent/grype-$agent_version.md" "$CVE_DIR/agent/grype-latest.md"
+	# We update latest until the final one so assuming the scan config is in order of releases.
 done
 
 # Run grype for each OSS version

--- a/scripts/security/run-scans.sh
+++ b/scripts/security/run-scans.sh
@@ -170,7 +170,7 @@ else
 		generateReports "$LATEST_AGENT_VERSION" "agent"
 	fi
 	# We copy the agent grype report to a "latest" file for easy reference in the main security.md document
-	cp "$CVE_DIR/agent/grype-$agent_version.md" "$CVE_DIR/agent/grype-latest.md"
+	cp -f "$CVE_DIR/agent/grype-$LATEST_AGENT_VERSION.md" "$CVE_DIR/agent/grype-latest.md"
 fi
 
 # Run grype for each OSS version

--- a/scripts/security/run-scans.sh
+++ b/scripts/security/run-scans.sh
@@ -160,7 +160,7 @@ LATEST_AGENT_VERSION=$(echo -n "$LATEST_AGENT_VERSION" | xargs)
 
 if [[ -z "$LATEST_AGENT_VERSION" ]]; then
 	echo "ERROR: Could not determine latest agent version from GitHub API, ensure gh CLI is authenticated correctly."
-	exit 0
+	exit 1
 else
 	# Check if latest version scan already exists
 	if [[ -f "$CVE_DIR/agent/grype-$LATEST_AGENT_VERSION.md" ]]; then
@@ -169,9 +169,15 @@ else
 		echo "Generating latest agent version scan for version: $LATEST_AGENT_VERSION"
 		generateReports "$LATEST_AGENT_VERSION" "agent"
 	fi
-	# We copy the agent grype report to a "latest" file for easy reference in the main security.md document
-	cp -f "$CVE_DIR/agent/grype-$LATEST_AGENT_VERSION.md" "$CVE_DIR/agent/grype-latest.md"
 fi
+
+if [[ ! -f "$CVE_DIR/agent/grype-$LATEST_AGENT_VERSION.md" ]]; then
+	echo "ERROR: Latest agent version scan file not found after generation attempt."
+	exit 1
+fi
+
+# We copy the agent grype report to a "latest" file for easy reference in the main security.md document
+cp -f "$CVE_DIR/agent/grype-$LATEST_AGENT_VERSION.md" "$CVE_DIR/agent/grype-latest.md"
 
 # Run grype for each OSS version
 for oss_version in "${OSS_VERSIONS[@]}"; do

--- a/scripts/security/run-scans.sh
+++ b/scripts/security/run-scans.sh
@@ -52,7 +52,7 @@ echo "All versions are valid semver format."
 mkdir -p "$CVE_DIR"/oss "$CVE_DIR"/agent
 
 # Check if syft and grype are installed
-if ! command -v syft &> /dev/null || ! command -v grype &> /dev/null || ! command -v jq &> /dev/null || ! command -v gh; then
+if ! command -v syft &> /dev/null || ! command -v grype &> /dev/null || ! command -v jq &> /dev/null || ! command -v gh &> /dev/null; then
     echo "ERROR: gh, jq, syft and grype must be installed to run this script."
     exit 1
 fi


### PR DESCRIPTION
Include the latest agent results for CVEs directly in the security page
Removes filesystem information included in Grype output.
Tested and updated generated VEX files to ensure they work with Grype and Trivy.

<!-- greptile_comment -->

## Greptile Summary

Updated On: 2025-09-05 15:43:14 UTC

This review covers only the changes made since the last review, not the entire PR. This PR improves CVE output handling for the FluentDo agent by standardizing VEX (Vulnerability Exploitability eXchange) file formats and enhancing documentation. The key changes include:

1. **VEX Format Standardization**: All VEX files have been updated to use generic OCI package identifiers (`pkg:oci/fluent-bit`) instead of Docker-specific formats with versions (`pkg:docker/fluent/fluent-bit:4.0.9`), making them more portable across different container registries and versions.

2. **Security Assessment Improvements**: The justification for CVE-2023-2953 has been updated from `inline_mitigations_already_exist` to `vulnerable_code_not_in_execute_path`, providing a more accurate security assessment.

3. **Documentation Enhancements**: Added practical usage examples showing how to consume the VEX endpoint with popular security tools like Trivy and Grype, plus comprehensive testing instructions.

4. **Code Quality Fix**: Fixed a minor syntax error in the security scanning script to ensure consistent error output redirection.

These changes align with the codebase's security documentation workflow in `docs/security/` and complement the automated scanning processes defined in the GitHub workflows. The VEX improvements make the security data more consumable by downstream security tools while maintaining compatibility with the existing triaged vulnerability management process.

## Important Files Changed

<details><summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| docs/security.md | 5/5 | Added VEX endpoint usage examples with Trivy and Grype commands |
| docs/security/triaged/README.md | 4/5 | Updated VEX generation process with OCI format and testing instructions |
| scripts/security/run-scans.sh | 5/5 | Fixed missing stderr redirection for gh command availability check |
| docs/security/triaged/CVE-2023-2953/triaged.vex.json | 4/5 | Standardized product identifier to OCI format and updated justification |
| docs/security/triaged/CVE-2023-2953/investigation.vex.json | 4/5 | Changed product identifier from Docker-specific to generic OCI format |
| docs/security/vex.json | 4/5 | Removed duplicate CVE entry and standardized to OCI package format |
| docs/security/triaged/CVE-2023-2953/vex.json | 4/5 | Updated package identifiers to use generic OCI format across all statements |

</details>

<!-- /greptile_comment -->