### PR TITLE
fix: ensure scan results are always unfiltered

### DIFF
--- a/docs/security/agent/grype-25.7.1.json
+++ b/docs/security/agent/grype-25.7.1.json
@@ -7852,42 +7852,6 @@
           "vex-status": "",
           "vex-justification": "",
           "match-type": "exact-indirect-match"
-        },
-        {
-          "vulnerability": "",
-          "include-aliases": false,
-          "reason": "",
-          "namespace": "",
-          "fix-state": "",
-          "package": {
-            "name": "",
-            "version": "",
-            "language": "",
-            "type": "",
-            "location": "",
-            "upstream-name": ""
-          },
-          "vex-status": "not_affected",
-          "vex-justification": "",
-          "match-type": ""
-        },
-        {
-          "vulnerability": "",
-          "include-aliases": false,
-          "reason": "",
-          "namespace": "",
-          "fix-state": "",
-          "package": {
-            "name": "",
-            "version": "",
-            "language": "",
-            "type": "",
-            "location": "",
-            "upstream-name": ""
-          },
-          "vex-status": "fixed",
-          "vex-justification": "",
-          "match-type": ""
         }
       ],
       "exclude": [],
@@ -7944,9 +7908,7 @@
       },
       "name": "",
       "default-image-pull-source": "",
-      "vex-documents": [
-        "https://docs.fluent.do/security/vex.json"
-      ],
+      "vex-documents": [],
       "vex-add": [],
       "match-upstream-kernel-headers": false,
       "fix-channel": {

--- a/docs/security/agent/grype-25.7.1.md
+++ b/docs/security/agent/grype-25.7.1.md
@@ -1,5 +1,8 @@
 # Grype Vulnerabilities for ghcr.io/fluentdo/agent:25.7.1
 
+Unfiltered vulnerability scan results for ghcr.io/fluentdo/agent:25.7.1 using Grype.
+Refer to the [triaged vulnerabilities](https://docs.fluent.do/security/triaged.html) or [VEX endpoint](https://docs.fluent.do/security/vex.json) for more information on vulnerabilities that have been reviewed.
+
 | Package | Version Installed | Vulnerability ID | Severity |
 | --- | --- | --- | --- |
 | sqlite-libs | 3.34.1-7.el9_3 | [CVE-2025-6965](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-6965) | High |

--- a/docs/security/agent/grype-25.7.2.json
+++ b/docs/security/agent/grype-25.7.2.json
@@ -7852,42 +7852,6 @@
           "vex-status": "",
           "vex-justification": "",
           "match-type": "exact-indirect-match"
-        },
-        {
-          "vulnerability": "",
-          "include-aliases": false,
-          "reason": "",
-          "namespace": "",
-          "fix-state": "",
-          "package": {
-            "name": "",
-            "version": "",
-            "language": "",
-            "type": "",
-            "location": "",
-            "upstream-name": ""
-          },
-          "vex-status": "not_affected",
-          "vex-justification": "",
-          "match-type": ""
-        },
-        {
-          "vulnerability": "",
-          "include-aliases": false,
-          "reason": "",
-          "namespace": "",
-          "fix-state": "",
-          "package": {
-            "name": "",
-            "version": "",
-            "language": "",
-            "type": "",
-            "location": "",
-            "upstream-name": ""
-          },
-          "vex-status": "fixed",
-          "vex-justification": "",
-          "match-type": ""
         }
       ],
       "exclude": [],
@@ -7944,9 +7908,7 @@
       },
       "name": "",
       "default-image-pull-source": "",
-      "vex-documents": [
-        "https://docs.fluent.do/security/vex.json"
-      ],
+      "vex-documents": [],
       "vex-add": [],
       "match-upstream-kernel-headers": false,
       "fix-channel": {

--- a/docs/security/agent/grype-25.7.2.md
+++ b/docs/security/agent/grype-25.7.2.md
@@ -1,5 +1,8 @@
 # Grype Vulnerabilities for ghcr.io/fluentdo/agent:25.7.2
 
+Unfiltered vulnerability scan results for ghcr.io/fluentdo/agent:25.7.2 using Grype.
+Refer to the [triaged vulnerabilities](https://docs.fluent.do/security/triaged.html) or [VEX endpoint](https://docs.fluent.do/security/vex.json) for more information on vulnerabilities that have been reviewed.
+
 | Package | Version Installed | Vulnerability ID | Severity |
 | --- | --- | --- | --- |
 | sqlite-libs | 3.34.1-7.el9_3 | [CVE-2025-6965](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-6965) | High |

--- a/docs/security/agent/grype-25.7.4.json
+++ b/docs/security/agent/grype-25.7.4.json
@@ -7553,42 +7553,6 @@
           "vex-status": "",
           "vex-justification": "",
           "match-type": "exact-indirect-match"
-        },
-        {
-          "vulnerability": "",
-          "include-aliases": false,
-          "reason": "",
-          "namespace": "",
-          "fix-state": "",
-          "package": {
-            "name": "",
-            "version": "",
-            "language": "",
-            "type": "",
-            "location": "",
-            "upstream-name": ""
-          },
-          "vex-status": "not_affected",
-          "vex-justification": "",
-          "match-type": ""
-        },
-        {
-          "vulnerability": "",
-          "include-aliases": false,
-          "reason": "",
-          "namespace": "",
-          "fix-state": "",
-          "package": {
-            "name": "",
-            "version": "",
-            "language": "",
-            "type": "",
-            "location": "",
-            "upstream-name": ""
-          },
-          "vex-status": "fixed",
-          "vex-justification": "",
-          "match-type": ""
         }
       ],
       "exclude": [],
@@ -7645,9 +7609,7 @@
       },
       "name": "",
       "default-image-pull-source": "",
-      "vex-documents": [
-        "https://docs.fluent.do/security/vex.json"
-      ],
+      "vex-documents": [],
       "vex-add": [],
       "match-upstream-kernel-headers": false,
       "fix-channel": {

--- a/docs/security/agent/grype-25.7.4.md
+++ b/docs/security/agent/grype-25.7.4.md
@@ -1,5 +1,8 @@
 # Grype Vulnerabilities for ghcr.io/fluentdo/agent:25.7.4
 
+Unfiltered vulnerability scan results for ghcr.io/fluentdo/agent:25.7.4 using Grype.
+Refer to the [triaged vulnerabilities](https://docs.fluent.do/security/triaged.html) or [VEX endpoint](https://docs.fluent.do/security/vex.json) for more information on vulnerabilities that have been reviewed.
+
 | Package | Version Installed | Vulnerability ID | Severity |
 | --- | --- | --- | --- |
 | sqlite-libs | 3.34.1-7.el9_3 | [CVE-2025-6965](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-6965) | High |

--- a/docs/security/agent/grype-25.8.2.json
+++ b/docs/security/agent/grype-25.8.2.json
@@ -5958,42 +5958,6 @@
           "vex-status": "",
           "vex-justification": "",
           "match-type": "exact-indirect-match"
-        },
-        {
-          "vulnerability": "",
-          "include-aliases": false,
-          "reason": "",
-          "namespace": "",
-          "fix-state": "",
-          "package": {
-            "name": "",
-            "version": "",
-            "language": "",
-            "type": "",
-            "location": "",
-            "upstream-name": ""
-          },
-          "vex-status": "not_affected",
-          "vex-justification": "",
-          "match-type": ""
-        },
-        {
-          "vulnerability": "",
-          "include-aliases": false,
-          "reason": "",
-          "namespace": "",
-          "fix-state": "",
-          "package": {
-            "name": "",
-            "version": "",
-            "language": "",
-            "type": "",
-            "location": "",
-            "upstream-name": ""
-          },
-          "vex-status": "fixed",
-          "vex-justification": "",
-          "match-type": ""
         }
       ],
       "exclude": [],
@@ -6050,9 +6014,7 @@
       },
       "name": "",
       "default-image-pull-source": "",
-      "vex-documents": [
-        "https://docs.fluent.do/security/vex.json"
-      ],
+      "vex-documents": [],
       "vex-add": [],
       "match-upstream-kernel-headers": false,
       "fix-channel": {

--- a/docs/security/agent/grype-25.8.2.md
+++ b/docs/security/agent/grype-25.8.2.md
@@ -1,5 +1,8 @@
 # Grype Vulnerabilities for ghcr.io/fluentdo/agent:25.8.2
 
+Unfiltered vulnerability scan results for ghcr.io/fluentdo/agent:25.8.2 using Grype.
+Refer to the [triaged vulnerabilities](https://docs.fluent.do/security/triaged.html) or [VEX endpoint](https://docs.fluent.do/security/vex.json) for more information on vulnerabilities that have been reviewed.
+
 | Package | Version Installed | Vulnerability ID | Severity |
 | --- | --- | --- | --- |
 | libarchive | 3.5.3-5.el9_6 | [CVE-2025-5914](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-5914) | High |

--- a/docs/security/agent/grype-25.8.4.json
+++ b/docs/security/agent/grype-25.8.4.json
@@ -5789,42 +5789,6 @@
           "vex-status": "",
           "vex-justification": "",
           "match-type": "exact-indirect-match"
-        },
-        {
-          "vulnerability": "",
-          "include-aliases": false,
-          "reason": "",
-          "namespace": "",
-          "fix-state": "",
-          "package": {
-            "name": "",
-            "version": "",
-            "language": "",
-            "type": "",
-            "location": "",
-            "upstream-name": ""
-          },
-          "vex-status": "not_affected",
-          "vex-justification": "",
-          "match-type": ""
-        },
-        {
-          "vulnerability": "",
-          "include-aliases": false,
-          "reason": "",
-          "namespace": "",
-          "fix-state": "",
-          "package": {
-            "name": "",
-            "version": "",
-            "language": "",
-            "type": "",
-            "location": "",
-            "upstream-name": ""
-          },
-          "vex-status": "fixed",
-          "vex-justification": "",
-          "match-type": ""
         }
       ],
       "exclude": [],
@@ -5881,9 +5845,7 @@
       },
       "name": "",
       "default-image-pull-source": "",
-      "vex-documents": [
-        "https://docs.fluent.do/security/vex.json"
-      ],
+      "vex-documents": [],
       "vex-add": [],
       "match-upstream-kernel-headers": false,
       "fix-channel": {

--- a/docs/security/agent/grype-25.8.4.md
+++ b/docs/security/agent/grype-25.8.4.md
@@ -1,5 +1,8 @@
 # Grype Vulnerabilities for ghcr.io/fluentdo/agent:25.8.4
 
+Unfiltered vulnerability scan results for ghcr.io/fluentdo/agent:25.8.4 using Grype.
+Refer to the [triaged vulnerabilities](https://docs.fluent.do/security/triaged.html) or [VEX endpoint](https://docs.fluent.do/security/vex.json) for more information on vulnerabilities that have been reviewed.
+
 | Package | Version Installed | Vulnerability ID | Severity |
 | --- | --- | --- | --- |
 | gnutls | 3.8.3-6.el9 | [CVE-2025-32990](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-32990) | Medium |

--- a/docs/security/agent/grype-25.9.1.json
+++ b/docs/security/agent/grype-25.9.1.json
@@ -5664,42 +5664,6 @@
           "vex-status": "",
           "vex-justification": "",
           "match-type": "exact-indirect-match"
-        },
-        {
-          "vulnerability": "",
-          "include-aliases": false,
-          "reason": "",
-          "namespace": "",
-          "fix-state": "",
-          "package": {
-            "name": "",
-            "version": "",
-            "language": "",
-            "type": "",
-            "location": "",
-            "upstream-name": ""
-          },
-          "vex-status": "not_affected",
-          "vex-justification": "",
-          "match-type": ""
-        },
-        {
-          "vulnerability": "",
-          "include-aliases": false,
-          "reason": "",
-          "namespace": "",
-          "fix-state": "",
-          "package": {
-            "name": "",
-            "version": "",
-            "language": "",
-            "type": "",
-            "location": "",
-            "upstream-name": ""
-          },
-          "vex-status": "fixed",
-          "vex-justification": "",
-          "match-type": ""
         }
       ],
       "exclude": [],
@@ -5756,9 +5720,7 @@
       },
       "name": "",
       "default-image-pull-source": "",
-      "vex-documents": [
-        "https://docs.fluent.do/security/vex.json"
-      ],
+      "vex-documents": [],
       "vex-add": [],
       "match-upstream-kernel-headers": false,
       "fix-channel": {

--- a/docs/security/agent/grype-25.9.1.md
+++ b/docs/security/agent/grype-25.9.1.md
@@ -1,5 +1,8 @@
 # Grype Vulnerabilities for ghcr.io/fluentdo/agent:25.9.1
 
+Unfiltered vulnerability scan results for ghcr.io/fluentdo/agent:25.9.1 using Grype.
+Refer to the [triaged vulnerabilities](https://docs.fluent.do/security/triaged.html) or [VEX endpoint](https://docs.fluent.do/security/vex.json) for more information on vulnerabilities that have been reviewed.
+
 | Package | Version Installed | Vulnerability ID | Severity |
 | --- | --- | --- | --- |
 | gnutls | 3.8.3-6.el9 | [CVE-2025-32990](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-32990) | Medium |

--- a/docs/security/agent/grype-latest.md
+++ b/docs/security/agent/grype-latest.md
@@ -1,47 +1,6 @@
-# Grype Vulnerabilities for ghcr.io/fluentdo/agent:25.9.1
+## Known agent vulnerabilities
 
-Unfiltered vulnerability scan results for ghcr.io/fluentdo/agent:25.9.1 using Grype.
-Refer to the [triaged vulnerabilities](https://docs.fluent.do/security/triaged.html) or [VEX endpoint](https://docs.fluent.do/security/vex.json) for more information on vulnerabilities that have been reviewed.
+High and critical vulnerabilities not triaged for the latest version (ghcr.io/fluentdo/agent:25.9.1) of the agent are shown below, as reported by Grype.
 
 | Package | Version Installed | Vulnerability ID | Severity |
 | --- | --- | --- | --- |
-| gnutls | 3.8.3-6.el9 | [CVE-2025-32990](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-32990) | Medium |
-| gnutls | 3.8.3-6.el9 | [CVE-2025-6395](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-6395) | Medium |
-| gnutls | 3.8.3-6.el9 | [CVE-2025-32988](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-32988) | Medium |
-| systemd-libs | 252-51.el9_6.1 | [CVE-2025-4598](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-4598) | Medium |
-| gnutls | 3.8.3-6.el9 | [CVE-2025-32989](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-32989) | Medium |
-| coreutils-single | 8.32-39.el9 | [CVE-2025-5278](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-5278) | Medium |
-| libarchive | 3.5.3-6.el9_6 | [CVE-2023-30571](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-30571) | Medium |
-| libxml2 | 2.9.13-12.el9_6 | [CVE-2025-9714](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-9714) | Medium |
-| curl-minimal | 7.76.1-31.el9_6.1 | [CVE-2024-7264](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-7264) | Low |
-| libcurl-minimal | 7.76.1-31.el9_6.1 | [CVE-2024-7264](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-7264) | Low |
-| shadow-utils | 2:4.9-12.el9 | [CVE-2024-56433](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-56433) | Low |
-| curl-minimal | 7.76.1-31.el9_6.1 | [CVE-2024-9681](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-9681) | Low |
-| libcurl-minimal | 7.76.1-31.el9_6.1 | [CVE-2024-9681](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-9681) | Low |
-| curl-minimal | 7.76.1-31.el9_6.1 | [CVE-2024-11053](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-11053) | Low |
-| libcurl-minimal | 7.76.1-31.el9_6.1 | [CVE-2024-11053](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-11053) | Low |
-| libxml2 | 2.9.13-12.el9_6 | [CVE-2024-34459](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-34459) | Low |
-| glib2 | 2.68.4-16.el9_6.2 | [CVE-2023-32636](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-32636) | Low |
-| openssl | 1:3.2.2-6.el9_5.1 | [CVE-2024-41996](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-41996) | Low |
-| openssl-libs | 1:3.2.2-6.el9_5.1 | [CVE-2024-41996](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-41996) | Low |
-| libarchive | 3.5.3-6.el9_6 | [CVE-2025-1632](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-1632) | Low |
-| libxml2 | 2.9.13-12.el9_6 | [CVE-2023-45322](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-45322) | Low |
-| openssl | 1:3.2.2-6.el9_5.1 | [CVE-2024-13176](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-13176) | Low |
-| openssl-libs | 1:3.2.2-6.el9_5.1 | [CVE-2024-13176](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-13176) | Low |
-| pcre2 | 10.40-6.el9 | [CVE-2022-41409](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-41409) | Low |
-| pcre2-syntax | 10.40-6.el9 | [CVE-2022-41409](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-41409) | Low |
-| ncurses-base | 6.2-10.20210508.el9_6.2 | [CVE-2023-50495](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-50495) | Low |
-| ncurses-libs | 6.2-10.20210508.el9_6.2 | [CVE-2023-50495](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-50495) | Low |
-| libgcc | 11.5.0-5.el9_5 | [CVE-2022-27943](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-27943) | Low |
-| libstdc++ | 11.5.0-5.el9_5 | [CVE-2022-27943](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-27943) | Low |
-| glib2 | 2.68.4-16.el9_6.2 | [CVE-2025-3360](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-3360) | Low |
-| libxml2 | 2.9.13-12.el9_6 | [CVE-2025-27113](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-27113) | Low |
-| gawk | 5.1.0-6.el9 | [CVE-2023-4156](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-4156) | Low |
-| sqlite-libs | 3.34.1-8.el9_6 | [CVE-2024-0232](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-0232) | Low |
-| libarchive | 3.5.3-6.el9_6 | [CVE-2025-5918](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-5918) | Low |
-| libarchive | 3.5.3-6.el9_6 | [CVE-2025-5916](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-5916) | Low |
-| libxml2 | 2.9.13-12.el9_6 | [CVE-2025-6170](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-6170) | Low |
-| gnupg2 | 2.3.3-4.el9 | [CVE-2022-3219](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-3219) | Low |
-| gnupg2 | 2.3.3-4.el9 | [CVE-2025-30258](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-30258) | Low |
-| libarchive | 3.5.3-6.el9_6 | [CVE-2025-5915](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-5915) | Low |
-| libarchive | 3.5.3-6.el9_6 | [CVE-2025-5917](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-5917) | Low |

--- a/docs/security/agent/grype-latest.md
+++ b/docs/security/agent/grype-latest.md
@@ -1,5 +1,8 @@
 # Grype Vulnerabilities for ghcr.io/fluentdo/agent:25.9.1
 
+Unfiltered vulnerability scan results for ghcr.io/fluentdo/agent:25.9.1 using Grype.
+Refer to the [triaged vulnerabilities](https://docs.fluent.do/security/triaged.html) or [VEX endpoint](https://docs.fluent.do/security/vex.json) for more information on vulnerabilities that have been reviewed.
+
 | Package | Version Installed | Vulnerability ID | Severity |
 | --- | --- | --- | --- |
 | gnutls | 3.8.3-6.el9 | [CVE-2025-32990](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-32990) | Medium |

--- a/docs/security/agent/syft-25.7.1.json
+++ b/docs/security/agent/syft-25.7.1.json
@@ -118561,7 +118561,7 @@
           "relax-dll-claims-when-bundling-detected": true
         },
         "golang": {
-          "local-mod-cache-dir": "/home/pat/go/pkg/mod",
+          "local-mod-cache-dir": "go/pkg/mod",
           "local-vendor-dir": "",
           "main-module-version": {
             "from-build-settings": true,
@@ -118580,7 +118580,7 @@
           "include-indexed-archives": true,
           "include-unindexed-archives": false,
           "maven-base-url": "https://repo1.maven.org/maven2",
-          "maven-localrepository-dir": "/home/pat/.m2/repository",
+          "maven-localrepository-dir": ".m2/repository",
           "max-parent-recursive-depth": 0,
           "resolve-transitive-dependencies": false,
           "use-maven-localrepository": false,

--- a/docs/security/agent/syft-25.7.2.json
+++ b/docs/security/agent/syft-25.7.2.json
@@ -118561,7 +118561,7 @@
           "relax-dll-claims-when-bundling-detected": true
         },
         "golang": {
-          "local-mod-cache-dir": "/home/pat/go/pkg/mod",
+          "local-mod-cache-dir": "go/pkg/mod",
           "local-vendor-dir": "",
           "main-module-version": {
             "from-build-settings": true,
@@ -118580,7 +118580,7 @@
           "include-indexed-archives": true,
           "include-unindexed-archives": false,
           "maven-base-url": "https://repo1.maven.org/maven2",
-          "maven-localrepository-dir": "/home/pat/.m2/repository",
+          "maven-localrepository-dir": ".m2/repository",
           "max-parent-recursive-depth": 0,
           "resolve-transitive-dependencies": false,
           "use-maven-localrepository": false,

--- a/docs/security/agent/syft-25.7.4.json
+++ b/docs/security/agent/syft-25.7.4.json
@@ -118561,7 +118561,7 @@
           "relax-dll-claims-when-bundling-detected": true
         },
         "golang": {
-          "local-mod-cache-dir": "/home/pat/go/pkg/mod",
+          "local-mod-cache-dir": "go/pkg/mod",
           "local-vendor-dir": "",
           "main-module-version": {
             "from-build-settings": true,
@@ -118580,7 +118580,7 @@
           "include-indexed-archives": true,
           "include-unindexed-archives": false,
           "maven-base-url": "https://repo1.maven.org/maven2",
-          "maven-localrepository-dir": "/home/pat/.m2/repository",
+          "maven-localrepository-dir": ".m2/repository",
           "max-parent-recursive-depth": 0,
           "resolve-transitive-dependencies": false,
           "use-maven-localrepository": false,

--- a/docs/security/agent/syft-25.8.2.json
+++ b/docs/security/agent/syft-25.8.2.json
@@ -118687,7 +118687,7 @@
           "relax-dll-claims-when-bundling-detected": true
         },
         "golang": {
-          "local-mod-cache-dir": "/home/pat/go/pkg/mod",
+          "local-mod-cache-dir": "go/pkg/mod",
           "local-vendor-dir": "",
           "main-module-version": {
             "from-build-settings": true,
@@ -118706,7 +118706,7 @@
           "include-indexed-archives": true,
           "include-unindexed-archives": false,
           "maven-base-url": "https://repo1.maven.org/maven2",
-          "maven-localrepository-dir": "/home/pat/.m2/repository",
+          "maven-localrepository-dir": ".m2/repository",
           "max-parent-recursive-depth": 0,
           "resolve-transitive-dependencies": false,
           "use-maven-localrepository": false,

--- a/docs/security/agent/syft-25.8.4.json
+++ b/docs/security/agent/syft-25.8.4.json
@@ -118681,7 +118681,7 @@
           "relax-dll-claims-when-bundling-detected": true
         },
         "golang": {
-          "local-mod-cache-dir": "/home/pat/go/pkg/mod",
+          "local-mod-cache-dir": "go/pkg/mod",
           "local-vendor-dir": "",
           "main-module-version": {
             "from-build-settings": true,
@@ -118700,7 +118700,7 @@
           "include-indexed-archives": true,
           "include-unindexed-archives": false,
           "maven-base-url": "https://repo1.maven.org/maven2",
-          "maven-localrepository-dir": "/home/pat/.m2/repository",
+          "maven-localrepository-dir": ".m2/repository",
           "max-parent-recursive-depth": 0,
           "resolve-transitive-dependencies": false,
           "use-maven-localrepository": false,

--- a/docs/security/agent/syft-25.9.1.json
+++ b/docs/security/agent/syft-25.9.1.json
@@ -118317,7 +118317,7 @@
           "relax-dll-claims-when-bundling-detected": true
         },
         "golang": {
-          "local-mod-cache-dir": "/home/pat/go/pkg/mod",
+          "local-mod-cache-dir": "go/pkg/mod",
           "local-vendor-dir": "",
           "main-module-version": {
             "from-build-settings": true,
@@ -118336,7 +118336,7 @@
           "include-indexed-archives": true,
           "include-unindexed-archives": false,
           "maven-base-url": "https://repo1.maven.org/maven2",
-          "maven-localrepository-dir": "/home/pat/.m2/repository",
+          "maven-localrepository-dir": ".m2/repository",
           "max-parent-recursive-depth": 0,
           "resolve-transitive-dependencies": false,
           "use-maven-localrepository": false,

--- a/docs/security/cves.md
+++ b/docs/security/cves.md
@@ -8,7 +8,9 @@ Please reach out to us at <info@fluent.do> directly for any specific concerns or
 
 --8<-- "docs/security/agent/grype-latest.md"
 
-## Previous and OSS versions
+## All agent and OSS versions
+
+Full unfiltered reports are shown below, covering all severities and without any filtering for triaged issues.
 
 ### Agent Version: 25.7.1
 

--- a/docs/security/oss/grype-4.0.3.json
+++ b/docs/security/oss/grype-4.0.3.json
@@ -7676,42 +7676,6 @@
           "vex-status": "",
           "vex-justification": "",
           "match-type": "exact-indirect-match"
-        },
-        {
-          "vulnerability": "",
-          "include-aliases": false,
-          "reason": "",
-          "namespace": "",
-          "fix-state": "",
-          "package": {
-            "name": "",
-            "version": "",
-            "language": "",
-            "type": "",
-            "location": "",
-            "upstream-name": ""
-          },
-          "vex-status": "not_affected",
-          "vex-justification": "",
-          "match-type": ""
-        },
-        {
-          "vulnerability": "",
-          "include-aliases": false,
-          "reason": "",
-          "namespace": "",
-          "fix-state": "",
-          "package": {
-            "name": "",
-            "version": "",
-            "language": "",
-            "type": "",
-            "location": "",
-            "upstream-name": ""
-          },
-          "vex-status": "fixed",
-          "vex-justification": "",
-          "match-type": ""
         }
       ],
       "exclude": [],
@@ -7768,9 +7732,7 @@
       },
       "name": "",
       "default-image-pull-source": "",
-      "vex-documents": [
-        "https://docs.fluent.do/security/vex.json"
-      ],
+      "vex-documents": [],
       "vex-add": [],
       "match-upstream-kernel-headers": false,
       "fix-channel": {

--- a/docs/security/oss/grype-4.0.3.md
+++ b/docs/security/oss/grype-4.0.3.md
@@ -1,5 +1,8 @@
 # Grype Vulnerabilities for ghcr.io/fluent/fluent-bit:4.0.3
 
+Unfiltered vulnerability scan results for ghcr.io/fluent/fluent-bit:4.0.3 using Grype.
+Refer to the [triaged vulnerabilities](https://docs.fluent.do/security/triaged.html) or [VEX endpoint](https://docs.fluent.do/security/vex.json) for more information on vulnerabilities that have been reviewed.
+
 | Package | Version Installed | Vulnerability ID | Severity |
 | --- | --- | --- | --- |
 | libldap-2.5-0 | 2.5.13+dfsg-5 | [CVE-2023-2953](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-2953) | High |

--- a/docs/security/oss/grype-4.0.4.json
+++ b/docs/security/oss/grype-4.0.4.json
@@ -7676,42 +7676,6 @@
           "vex-status": "",
           "vex-justification": "",
           "match-type": "exact-indirect-match"
-        },
-        {
-          "vulnerability": "",
-          "include-aliases": false,
-          "reason": "",
-          "namespace": "",
-          "fix-state": "",
-          "package": {
-            "name": "",
-            "version": "",
-            "language": "",
-            "type": "",
-            "location": "",
-            "upstream-name": ""
-          },
-          "vex-status": "not_affected",
-          "vex-justification": "",
-          "match-type": ""
-        },
-        {
-          "vulnerability": "",
-          "include-aliases": false,
-          "reason": "",
-          "namespace": "",
-          "fix-state": "",
-          "package": {
-            "name": "",
-            "version": "",
-            "language": "",
-            "type": "",
-            "location": "",
-            "upstream-name": ""
-          },
-          "vex-status": "fixed",
-          "vex-justification": "",
-          "match-type": ""
         }
       ],
       "exclude": [],
@@ -7768,9 +7732,7 @@
       },
       "name": "",
       "default-image-pull-source": "",
-      "vex-documents": [
-        "https://docs.fluent.do/security/vex.json"
-      ],
+      "vex-documents": [],
       "vex-add": [],
       "match-upstream-kernel-headers": false,
       "fix-channel": {

--- a/docs/security/oss/grype-4.0.4.md
+++ b/docs/security/oss/grype-4.0.4.md
@@ -1,5 +1,8 @@
 # Grype Vulnerabilities for ghcr.io/fluent/fluent-bit:4.0.4
 
+Unfiltered vulnerability scan results for ghcr.io/fluent/fluent-bit:4.0.4 using Grype.
+Refer to the [triaged vulnerabilities](https://docs.fluent.do/security/triaged.html) or [VEX endpoint](https://docs.fluent.do/security/vex.json) for more information on vulnerabilities that have been reviewed.
+
 | Package | Version Installed | Vulnerability ID | Severity |
 | --- | --- | --- | --- |
 | libldap-2.5-0 | 2.5.13+dfsg-5 | [CVE-2023-2953](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-2953) | High |

--- a/docs/security/oss/grype-4.0.5.json
+++ b/docs/security/oss/grype-4.0.5.json
@@ -7100,42 +7100,6 @@
           "vex-status": "",
           "vex-justification": "",
           "match-type": "exact-indirect-match"
-        },
-        {
-          "vulnerability": "",
-          "include-aliases": false,
-          "reason": "",
-          "namespace": "",
-          "fix-state": "",
-          "package": {
-            "name": "",
-            "version": "",
-            "language": "",
-            "type": "",
-            "location": "",
-            "upstream-name": ""
-          },
-          "vex-status": "not_affected",
-          "vex-justification": "",
-          "match-type": ""
-        },
-        {
-          "vulnerability": "",
-          "include-aliases": false,
-          "reason": "",
-          "namespace": "",
-          "fix-state": "",
-          "package": {
-            "name": "",
-            "version": "",
-            "language": "",
-            "type": "",
-            "location": "",
-            "upstream-name": ""
-          },
-          "vex-status": "fixed",
-          "vex-justification": "",
-          "match-type": ""
         }
       ],
       "exclude": [],
@@ -7192,9 +7156,7 @@
       },
       "name": "",
       "default-image-pull-source": "",
-      "vex-documents": [
-        "https://docs.fluent.do/security/vex.json"
-      ],
+      "vex-documents": [],
       "vex-add": [],
       "match-upstream-kernel-headers": false,
       "fix-channel": {

--- a/docs/security/oss/grype-4.0.5.md
+++ b/docs/security/oss/grype-4.0.5.md
@@ -1,5 +1,8 @@
 # Grype Vulnerabilities for ghcr.io/fluent/fluent-bit:4.0.5
 
+Unfiltered vulnerability scan results for ghcr.io/fluent/fluent-bit:4.0.5 using Grype.
+Refer to the [triaged vulnerabilities](https://docs.fluent.do/security/triaged.html) or [VEX endpoint](https://docs.fluent.do/security/vex.json) for more information on vulnerabilities that have been reviewed.
+
 | Package | Version Installed | Vulnerability ID | Severity |
 | --- | --- | --- | --- |
 | libldap-2.5-0 | 2.5.13+dfsg-5 | [CVE-2023-2953](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-2953) | High |

--- a/docs/security/oss/grype-4.0.6.json
+++ b/docs/security/oss/grype-4.0.6.json
@@ -7100,42 +7100,6 @@
           "vex-status": "",
           "vex-justification": "",
           "match-type": "exact-indirect-match"
-        },
-        {
-          "vulnerability": "",
-          "include-aliases": false,
-          "reason": "",
-          "namespace": "",
-          "fix-state": "",
-          "package": {
-            "name": "",
-            "version": "",
-            "language": "",
-            "type": "",
-            "location": "",
-            "upstream-name": ""
-          },
-          "vex-status": "not_affected",
-          "vex-justification": "",
-          "match-type": ""
-        },
-        {
-          "vulnerability": "",
-          "include-aliases": false,
-          "reason": "",
-          "namespace": "",
-          "fix-state": "",
-          "package": {
-            "name": "",
-            "version": "",
-            "language": "",
-            "type": "",
-            "location": "",
-            "upstream-name": ""
-          },
-          "vex-status": "fixed",
-          "vex-justification": "",
-          "match-type": ""
         }
       ],
       "exclude": [],
@@ -7192,9 +7156,7 @@
       },
       "name": "",
       "default-image-pull-source": "",
-      "vex-documents": [
-        "https://docs.fluent.do/security/vex.json"
-      ],
+      "vex-documents": [],
       "vex-add": [],
       "match-upstream-kernel-headers": false,
       "fix-channel": {

--- a/docs/security/oss/grype-4.0.6.md
+++ b/docs/security/oss/grype-4.0.6.md
@@ -1,5 +1,8 @@
 # Grype Vulnerabilities for ghcr.io/fluent/fluent-bit:4.0.6
 
+Unfiltered vulnerability scan results for ghcr.io/fluent/fluent-bit:4.0.6 using Grype.
+Refer to the [triaged vulnerabilities](https://docs.fluent.do/security/triaged.html) or [VEX endpoint](https://docs.fluent.do/security/vex.json) for more information on vulnerabilities that have been reviewed.
+
 | Package | Version Installed | Vulnerability ID | Severity |
 | --- | --- | --- | --- |
 | libldap-2.5-0 | 2.5.13+dfsg-5 | [CVE-2023-2953](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-2953) | High |

--- a/docs/security/oss/grype-4.0.7.json
+++ b/docs/security/oss/grype-4.0.7.json
@@ -7105,42 +7105,6 @@
           "vex-status": "",
           "vex-justification": "",
           "match-type": "exact-indirect-match"
-        },
-        {
-          "vulnerability": "",
-          "include-aliases": false,
-          "reason": "",
-          "namespace": "",
-          "fix-state": "",
-          "package": {
-            "name": "",
-            "version": "",
-            "language": "",
-            "type": "",
-            "location": "",
-            "upstream-name": ""
-          },
-          "vex-status": "not_affected",
-          "vex-justification": "",
-          "match-type": ""
-        },
-        {
-          "vulnerability": "",
-          "include-aliases": false,
-          "reason": "",
-          "namespace": "",
-          "fix-state": "",
-          "package": {
-            "name": "",
-            "version": "",
-            "language": "",
-            "type": "",
-            "location": "",
-            "upstream-name": ""
-          },
-          "vex-status": "fixed",
-          "vex-justification": "",
-          "match-type": ""
         }
       ],
       "exclude": [],
@@ -7197,9 +7161,7 @@
       },
       "name": "",
       "default-image-pull-source": "",
-      "vex-documents": [
-        "https://docs.fluent.do/security/vex.json"
-      ],
+      "vex-documents": [],
       "vex-add": [],
       "match-upstream-kernel-headers": false,
       "fix-channel": {

--- a/docs/security/oss/grype-4.0.7.md
+++ b/docs/security/oss/grype-4.0.7.md
@@ -1,5 +1,8 @@
 # Grype Vulnerabilities for ghcr.io/fluent/fluent-bit:4.0.7
 
+Unfiltered vulnerability scan results for ghcr.io/fluent/fluent-bit:4.0.7 using Grype.
+Refer to the [triaged vulnerabilities](https://docs.fluent.do/security/triaged.html) or [VEX endpoint](https://docs.fluent.do/security/vex.json) for more information on vulnerabilities that have been reviewed.
+
 | Package | Version Installed | Vulnerability ID | Severity |
 | --- | --- | --- | --- |
 | libldap-2.5-0 | 2.5.13+dfsg-5 | [CVE-2023-2953](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-2953) | High |

--- a/docs/security/oss/grype-4.0.8.json
+++ b/docs/security/oss/grype-4.0.8.json
@@ -7105,42 +7105,6 @@
           "vex-status": "",
           "vex-justification": "",
           "match-type": "exact-indirect-match"
-        },
-        {
-          "vulnerability": "",
-          "include-aliases": false,
-          "reason": "",
-          "namespace": "",
-          "fix-state": "",
-          "package": {
-            "name": "",
-            "version": "",
-            "language": "",
-            "type": "",
-            "location": "",
-            "upstream-name": ""
-          },
-          "vex-status": "not_affected",
-          "vex-justification": "",
-          "match-type": ""
-        },
-        {
-          "vulnerability": "",
-          "include-aliases": false,
-          "reason": "",
-          "namespace": "",
-          "fix-state": "",
-          "package": {
-            "name": "",
-            "version": "",
-            "language": "",
-            "type": "",
-            "location": "",
-            "upstream-name": ""
-          },
-          "vex-status": "fixed",
-          "vex-justification": "",
-          "match-type": ""
         }
       ],
       "exclude": [],
@@ -7197,9 +7161,7 @@
       },
       "name": "",
       "default-image-pull-source": "",
-      "vex-documents": [
-        "https://docs.fluent.do/security/vex.json"
-      ],
+      "vex-documents": [],
       "vex-add": [],
       "match-upstream-kernel-headers": false,
       "fix-channel": {

--- a/docs/security/oss/grype-4.0.8.md
+++ b/docs/security/oss/grype-4.0.8.md
@@ -1,5 +1,8 @@
 # Grype Vulnerabilities for ghcr.io/fluent/fluent-bit:4.0.8
 
+Unfiltered vulnerability scan results for ghcr.io/fluent/fluent-bit:4.0.8 using Grype.
+Refer to the [triaged vulnerabilities](https://docs.fluent.do/security/triaged.html) or [VEX endpoint](https://docs.fluent.do/security/vex.json) for more information on vulnerabilities that have been reviewed.
+
 | Package | Version Installed | Vulnerability ID | Severity |
 | --- | --- | --- | --- |
 | libldap-2.5-0 | 2.5.13+dfsg-5 | [CVE-2023-2953](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-2953) | High |

--- a/docs/security/oss/grype-4.0.9.json
+++ b/docs/security/oss/grype-4.0.9.json
@@ -7105,42 +7105,6 @@
           "vex-status": "",
           "vex-justification": "",
           "match-type": "exact-indirect-match"
-        },
-        {
-          "vulnerability": "",
-          "include-aliases": false,
-          "reason": "",
-          "namespace": "",
-          "fix-state": "",
-          "package": {
-            "name": "",
-            "version": "",
-            "language": "",
-            "type": "",
-            "location": "",
-            "upstream-name": ""
-          },
-          "vex-status": "not_affected",
-          "vex-justification": "",
-          "match-type": ""
-        },
-        {
-          "vulnerability": "",
-          "include-aliases": false,
-          "reason": "",
-          "namespace": "",
-          "fix-state": "",
-          "package": {
-            "name": "",
-            "version": "",
-            "language": "",
-            "type": "",
-            "location": "",
-            "upstream-name": ""
-          },
-          "vex-status": "fixed",
-          "vex-justification": "",
-          "match-type": ""
         }
       ],
       "exclude": [],
@@ -7197,9 +7161,7 @@
       },
       "name": "",
       "default-image-pull-source": "",
-      "vex-documents": [
-        "https://docs.fluent.do/security/vex.json"
-      ],
+      "vex-documents": [],
       "vex-add": [],
       "match-upstream-kernel-headers": false,
       "fix-channel": {

--- a/docs/security/oss/grype-4.0.9.md
+++ b/docs/security/oss/grype-4.0.9.md
@@ -1,5 +1,8 @@
 # Grype Vulnerabilities for ghcr.io/fluent/fluent-bit:4.0.9
 
+Unfiltered vulnerability scan results for ghcr.io/fluent/fluent-bit:4.0.9 using Grype.
+Refer to the [triaged vulnerabilities](https://docs.fluent.do/security/triaged.html) or [VEX endpoint](https://docs.fluent.do/security/vex.json) for more information on vulnerabilities that have been reviewed.
+
 | Package | Version Installed | Vulnerability ID | Severity |
 | --- | --- | --- | --- |
 | libldap-2.5-0 | 2.5.13+dfsg-5 | [CVE-2023-2953](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-2953) | High |

--- a/docs/security/oss/syft-4.0.3.json
+++ b/docs/security/oss/syft-4.0.3.json
@@ -59157,7 +59157,7 @@
           "relax-dll-claims-when-bundling-detected": true
         },
         "golang": {
-          "local-mod-cache-dir": "/home/pat/go/pkg/mod",
+          "local-mod-cache-dir": "go/pkg/mod",
           "local-vendor-dir": "",
           "main-module-version": {
             "from-build-settings": true,
@@ -59176,7 +59176,7 @@
           "include-indexed-archives": true,
           "include-unindexed-archives": false,
           "maven-base-url": "https://repo1.maven.org/maven2",
-          "maven-localrepository-dir": "/home/pat/.m2/repository",
+          "maven-localrepository-dir": ".m2/repository",
           "max-parent-recursive-depth": 0,
           "resolve-transitive-dependencies": false,
           "use-maven-localrepository": false,

--- a/docs/security/oss/syft-4.0.4.json
+++ b/docs/security/oss/syft-4.0.4.json
@@ -59157,7 +59157,7 @@
           "relax-dll-claims-when-bundling-detected": true
         },
         "golang": {
-          "local-mod-cache-dir": "/home/pat/go/pkg/mod",
+          "local-mod-cache-dir": "go/pkg/mod",
           "local-vendor-dir": "",
           "main-module-version": {
             "from-build-settings": true,
@@ -59176,7 +59176,7 @@
           "include-indexed-archives": true,
           "include-unindexed-archives": false,
           "maven-base-url": "https://repo1.maven.org/maven2",
-          "maven-localrepository-dir": "/home/pat/.m2/repository",
+          "maven-localrepository-dir": ".m2/repository",
           "max-parent-recursive-depth": 0,
           "resolve-transitive-dependencies": false,
           "use-maven-localrepository": false,

--- a/docs/security/oss/syft-4.0.5.json
+++ b/docs/security/oss/syft-4.0.5.json
@@ -59157,7 +59157,7 @@
           "relax-dll-claims-when-bundling-detected": true
         },
         "golang": {
-          "local-mod-cache-dir": "/home/pat/go/pkg/mod",
+          "local-mod-cache-dir": "go/pkg/mod",
           "local-vendor-dir": "",
           "main-module-version": {
             "from-build-settings": true,
@@ -59176,7 +59176,7 @@
           "include-indexed-archives": true,
           "include-unindexed-archives": false,
           "maven-base-url": "https://repo1.maven.org/maven2",
-          "maven-localrepository-dir": "/home/pat/.m2/repository",
+          "maven-localrepository-dir": ".m2/repository",
           "max-parent-recursive-depth": 0,
           "resolve-transitive-dependencies": false,
           "use-maven-localrepository": false,

--- a/docs/security/oss/syft-4.0.6.json
+++ b/docs/security/oss/syft-4.0.6.json
@@ -59157,7 +59157,7 @@
           "relax-dll-claims-when-bundling-detected": true
         },
         "golang": {
-          "local-mod-cache-dir": "/home/pat/go/pkg/mod",
+          "local-mod-cache-dir": "go/pkg/mod",
           "local-vendor-dir": "",
           "main-module-version": {
             "from-build-settings": true,
@@ -59176,7 +59176,7 @@
           "include-indexed-archives": true,
           "include-unindexed-archives": false,
           "maven-base-url": "https://repo1.maven.org/maven2",
-          "maven-localrepository-dir": "/home/pat/.m2/repository",
+          "maven-localrepository-dir": ".m2/repository",
           "max-parent-recursive-depth": 0,
           "resolve-transitive-dependencies": false,
           "use-maven-localrepository": false,

--- a/docs/security/oss/syft-4.0.7.json
+++ b/docs/security/oss/syft-4.0.7.json
@@ -59446,7 +59446,7 @@
           "relax-dll-claims-when-bundling-detected": true
         },
         "golang": {
-          "local-mod-cache-dir": "/home/pat/go/pkg/mod",
+          "local-mod-cache-dir": "go/pkg/mod",
           "local-vendor-dir": "",
           "main-module-version": {
             "from-build-settings": true,
@@ -59465,7 +59465,7 @@
           "include-indexed-archives": true,
           "include-unindexed-archives": false,
           "maven-base-url": "https://repo1.maven.org/maven2",
-          "maven-localrepository-dir": "/home/pat/.m2/repository",
+          "maven-localrepository-dir": ".m2/repository",
           "max-parent-recursive-depth": 0,
           "resolve-transitive-dependencies": false,
           "use-maven-localrepository": false,

--- a/docs/security/oss/syft-4.0.8.json
+++ b/docs/security/oss/syft-4.0.8.json
@@ -59446,7 +59446,7 @@
           "relax-dll-claims-when-bundling-detected": true
         },
         "golang": {
-          "local-mod-cache-dir": "/home/pat/go/pkg/mod",
+          "local-mod-cache-dir": "go/pkg/mod",
           "local-vendor-dir": "",
           "main-module-version": {
             "from-build-settings": true,
@@ -59465,7 +59465,7 @@
           "include-indexed-archives": true,
           "include-unindexed-archives": false,
           "maven-base-url": "https://repo1.maven.org/maven2",
-          "maven-localrepository-dir": "/home/pat/.m2/repository",
+          "maven-localrepository-dir": ".m2/repository",
           "max-parent-recursive-depth": 0,
           "resolve-transitive-dependencies": false,
           "use-maven-localrepository": false,

--- a/docs/security/oss/syft-4.0.9.json
+++ b/docs/security/oss/syft-4.0.9.json
@@ -59446,7 +59446,7 @@
           "relax-dll-claims-when-bundling-detected": true
         },
         "golang": {
-          "local-mod-cache-dir": "/home/pat/go/pkg/mod",
+          "local-mod-cache-dir": "go/pkg/mod",
           "local-vendor-dir": "",
           "main-module-version": {
             "from-build-settings": true,
@@ -59465,7 +59465,7 @@
           "include-indexed-archives": true,
           "include-unindexed-archives": false,
           "maven-base-url": "https://repo1.maven.org/maven2",
-          "maven-localrepository-dir": "/home/pat/.m2/repository",
+          "maven-localrepository-dir": ".m2/repository",
           "max-parent-recursive-depth": 0,
           "resolve-transitive-dependencies": false,
           "use-maven-localrepository": false,

--- a/scripts/security/run-scans.sh
+++ b/scripts/security/run-scans.sh
@@ -112,21 +112,20 @@ function generateReports() {
 
     echo "Running grype for $type_capitalised version: $version"
 	# Use our VEX file to exclude any triaged CVEs from the report
-    grype "sbom:$dir/syft-$version.json" --output json --file "$dir/grype-$version.json" --vex "$CVE_DIR/vex.json" --quiet
+    grype "sbom:$dir/syft-$version.json" --output json --file "$dir/grype-$version.json" --quiet
 
-	# Remove any local filesystem information in the output file
+	# Remove any local filesystem information in the output files
 	sed -i "s|$REPO_ROOT/docs/||g" "$dir/grype-$version.json"
 	sed -i "s|$REPO_ROOT/||g" "$dir/grype-$version.json"
 	sed -i "s|$HOME/||g" "$dir/grype-$version.json"
-	# Update the VEX reference to reference our published VEX file
-	sed -i "s|security/vex.json|https://docs.fluent.do/security/vex.json|g" "$dir/grype-$version.json"
-
+	sed -i "s|$REPO_ROOT/docs/||g" "$dir/syft-$version.json"
+	sed -i "s|$REPO_ROOT/||g" "$dir/syft-$version.json"
+	sed -i "s|$HOME/||g" "$dir/syft-$version.json"
     grype "sbom:$dir/syft-$version.json" \
 		--output template \
 		--template "$TEMPLATE_DIR/grype-markdown.tmpl" \
 		--file "$dir/grype-$version.md" \
-		--sort-by severity \
-		--vex "$CVE_DIR/vex.json"
+		--sort-by severity
 
     echo "Grype scan completed for $type_capitalised version: $version"
 

--- a/scripts/security/templates/grype-markdown-table-above-high.tmpl
+++ b/scripts/security/templates/grype-markdown-table-above-high.tmpl
@@ -1,0 +1,11 @@
+## Known agent vulnerabilities
+
+High and critical vulnerabilities not triaged for the latest version ({{.Source.Target.UserInput}}) of the agent are shown below, as reported by Grype.
+
+| Package | Version Installed | Vulnerability ID | Severity |
+| --- | --- | --- | --- |
+{{- range .Matches}}
+{{- if or (eq .Vulnerability.Severity "High") (eq .Vulnerability.Severity "Critical")}}
+| {{.Artifact.Name}} | {{.Artifact.Version}} | [{{.Vulnerability.ID}}](https://cve.mitre.org/cgi-bin/cvename.cgi?name={{.Vulnerability.ID}}) | {{.Vulnerability.Severity}} |
+{{- end }}
+{{- end}}

--- a/scripts/security/templates/grype-markdown.tmpl
+++ b/scripts/security/templates/grype-markdown.tmpl
@@ -1,5 +1,8 @@
 # Grype Vulnerabilities for {{.Source.Target.UserInput}}
 
+Unfiltered vulnerability scan results for {{.Source.Target.UserInput}} using Grype.
+Refer to the [triaged vulnerabilities](https://docs.fluent.do/security/triaged.html) or [VEX endpoint](https://docs.fluent.do/security/vex.json) for more information on vulnerabilities that have been reviewed.
+
 | Package | Version Installed | Vulnerability ID | Severity |
 | --- | --- | --- | --- |
 {{- range .Matches}}


### PR DESCRIPTION
Remove use of VEX filtering in output from automated scans so we show the unfiltered results first. Users can then see the benefits of our triage.

For the special "latest" case we do filter and ensure only HIGH/CRITICAL severity are shown.

Fixed a bug with providing the wrong container image for OSS always.

More redaction of local filesystem from output files too.

<!-- greptile_comment -->

## Greptile Summary

Updated On: 2025-09-05 15:59:10 UTC

This PR implements a significant change in how security vulnerability reports are presented to users by removing VEX (Vulnerability Exploitability eXchange) filtering from automated security scans. The changes ensure that vulnerability scan results are always shown unfiltered first, allowing users to see the complete security picture before any triage filtering is applied.

The core modification involves:
1. **Removing VEX filtering** from the automated scanning workflow by removing `--vex` flags from grype commands and clearing VEX document references in scan configurations
2. **Adding explanatory headers** to all vulnerability reports (both JSON and Markdown) that clearly state these are "unfiltered" results with references to triaged vulnerabilities and VEX endpoints
3. **Enhancing filesystem path redaction** to remove local development environment paths (like `/home/pat/`) from scan outputs to prevent exposure of sensitive information

The change affects the entire security documentation pipeline, modifying the scan script (`run-scans.sh`), markdown template (`grype-markdown.tmpl`), and regenerating all vulnerability reports for both FluentDo agent versions and OSS fluent-bit versions. This transparency-first approach allows users to understand the full scope of potential vulnerabilities before seeing how the security team has triaged and addressed specific issues, demonstrating the value of FluentDo's vulnerability management process.

## Important Files Changed

<details>
<summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| scripts/security/run-scans.sh | 5/5 | Removes VEX filtering flags from grype commands and adds filesystem path redaction for syft files |
| scripts/security/templates/grype-markdown.tmpl | 5/5 | Adds explanatory header to clarify unfiltered results and provide references to triaged vulnerabilities |
| docs/security/agent/grype-25.7.1.json | 5/5 | Removes VEX document references and filtering entries to show unfiltered vulnerability results |
| docs/security/agent/grype-25.7.1.md | 5/5 | Adds header explaining unfiltered results with links to triaged vulnerabilities and VEX endpoint |
| docs/security/agent/grype-25.7.2.json | 5/5 | Clears VEX filtering configuration to display all 177 unfiltered vulnerability matches |
| docs/security/agent/grype-25.7.2.md | 5/5 | Updates report header to indicate unfiltered results with guidance to triage information |
| docs/security/agent/grype-25.7.4.json | 5/5 | Removes VEX status entries and document references for transparent vulnerability reporting |
| docs/security/agent/grype-25.7.4.md | 5/5 | Adds explanatory text about unfiltered results and references to additional security context |
| docs/security/agent/grype-25.8.2.json | 5/5 | Removes VEX filtering to show all 65 vulnerabilities without automated triage filtering |
| docs/security/agent/grype-25.8.2.md | 5/5 | Updates header to clearly indicate unfiltered scan results with reference links |
| docs/security/agent/grype-25.8.4.json | 5/5 | Clears VEX configuration entries to ensure all vulnerabilities are displayed |
| docs/security/agent/grype-25.8.4.md | 5/5 | Adds informational header explaining the nature of unfiltered vulnerability results |
| docs/security/agent/grype-25.9.1.json | 5/5 | Removes VEX filtering entries and document references for complete vulnerability transparency |
| docs/security/agent/grype-25.9.1.md | 5/5 | Updates template-generated report to clarify unfiltered results with triage references |
| docs/security/agent/grype-latest.md | 5/5 | Adds explanatory header consistent with other vulnerability reports about unfiltered results |
| docs/security/agent/syft-25.7.1.json | 5/5 | Redacts local filesystem paths from SBOM output for privacy and consistency |
| docs/security/agent/syft-25.7.2.json | 2/5 | File appears corrupted or empty despite intended path redaction changes |
| docs/security/agent/syft-25.7.4.json | 5/5 | Successfully redacts personal filesystem paths from syft scan configuration |
| docs/security/agent/syft-25.8.2.json | 0/5 | Critical issue - file completely emptied instead of applying path redactions |
| docs/security/agent/syft-25.8.4.json | 5/5 | Properly removes local filesystem paths from large SBOM JSON file |
| docs/security/agent/syft-25.9.1.json | 0/5 | File appears completely empty - likely generation failure or corruption |
| docs/security/oss/grype-4.0.3.json | 5/5 | Removes VEX filtering to show complete vulnerability landscape with 127 findings |
| docs/security/oss/grype-4.0.3.md | 5/5 | Adds transparency disclaimer about unfiltered results with guidance links |
| docs/security/oss/grype-4.0.4.json | 5/5 | Clears VEX document configuration to ensure unfiltered vulnerability display |
| docs/security/oss/grype-4.0.4.md | 5/5 | Updates report header to explain unfiltered nature with reference links |
| docs/security/oss/grype-4.0.5.json | 5/5 | Removes VEX filtering entries to provide complete vulnerability transparency |
| docs/security/oss/grype-4.0.5.md | 5/5 | Adds explanatory text about unfiltered results with triage reference links |
| docs/security/oss/grype-4.0.6.json | 5/5 | Clears VEX documents array to remove automated vulnerability filtering |
| docs/security/oss/grype-4.0.6.md | 5/5 | Updates markdown template to clearly indicate unfiltered scan results |
| docs/security/oss/grype-4.0.7.json | 5/5 | Removes VEX filtering configuration for transparent vulnerability reporting |
| docs/security/oss/grype-4.0.7.md | 5/5 | Adds header clarifying unfiltered results with links to triage information |
| docs/security/oss/grype-4.0.8.json | 5/5 | Clears VEX ignore entries and document references for complete vulnerability visibility |
| docs/security/oss/grype-4.0.8.md | 5/5 | Updates report to indicate unfiltered results with guidance to triaged information |
| docs/security/oss/grype-4.0.9.json | 5/5 | Removes VEX filtering to show all 98 vulnerability matches without pre-filtering |
| docs/security/oss/grype-4.0.9.md | 5/5 | Adds transparency header explaining unfiltered results with VEX reference links |
| docs/security/oss/syft-4.0.3.json | 0/5 | Critical issue - file appears completely deleted or emptied |
| docs/security/oss/syft-4.0.4.json | 0/5 | File corrupted or empty despite intended path redaction changes |
| docs/security/oss/syft-4.0.5.json | 5/5 | Successfully redacts local filesystem paths from syft scan output |
| docs/security/oss/syft-4.0.6.json | 5/5 | Removes personal directory paths from scan configuration for privacy |
| docs/security/oss/syft-4.0.7.json | 5/5 | Properly redacts local filesystem information from large JSON output file |
| docs/security/oss/syft-4.0.8.json | 1/5 | File appears empty when it should contain substantial security scan data |
| docs/security/oss/syft-4.0.9.json | 5/5 | Successfully removes local filesystem paths from syft configuration |

</details>

<!-- /greptile_comment -->