### PR TITLE
feat: add K8S supported versions info

### DIFF
--- a/docs/supported-platforms.md
+++ b/docs/supported-platforms.md
@@ -6,7 +6,7 @@ Releases can be found or watched here: <https://github.com/FluentDo/releases>
 
 ## Kubernetes versions
 
-We support all mainstream Kubernetes providers including Digital Ocean, Openshift, EKS (AWS), GKS (Google), AKS (Microsoft) and all their supported versions as well.
+We support all mainstream Kubernetes providers including Digital Ocean, Openshift, EKS (AWS), GKE (Google), AKS (Microsoft) and all their supported versions as well.
 
 We test against a matrix of vanilla Kubernetes versions along with the various distributions and configurations required by customers to guarantee the use cases they require are supported.
 


### PR DESCRIPTION
Simple update to indicate we support all K8S versions people want.

<!-- greptile_comment -->

## Greptile Summary

Updated On: 2025-09-11 10:53:35 UTC

This review covers only the changes made since the last review, not the entire PR. The current change corrects a minor typo in the Kubernetes versions section of the supported platforms documentation, changing 'GKS' to 'GKE' for Google Kubernetes Engine.

This correction addresses a factual error that was identified in the previous review. The change improves the accuracy of customer-facing documentation by using the correct acronym for Google's Kubernetes service. Since the `docs/supported-platforms.md` file serves as a reference for enterprise customers evaluating FluentDo Agent's platform compatibility, having accurate service names is essential for maintaining professional credibility.

The fix fits naturally within the existing documentation structure, which already contains platform support information for the FluentDo project. This type of technical accuracy is particularly important in enterprise software documentation where customers rely on precise information to make adoption decisions.

## Important Files Changed

<details><summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|
| docs/supported-platforms.md | 5/5 | Fixed typo changing 'GKS' to 'GKE' for correct Google Kubernetes Engine naming |

</details>

## Confidence score: 5/5

- This PR is safe to merge with minimal risk as it only corrects a factual error in documentation
- Score reflects a simple, accurate correction that improves documentation quality without introducing any technical risks
- No files require special attention as this is a straightforward typo fix

<!-- /greptile_comment -->