### PR TITLE
fix: ensure we authenticate with gh CLI

### DIFF
--- a/.github/workflows/call-add-mapping-version.yaml
+++ b/.github/workflows/call-add-mapping-version.yaml
@@ -51,6 +51,13 @@ jobs:
           curl -sSfL https://get.anchore.io/syft | sudo sh -s -- -b /usr/local/bin
         shell: bash
 
+      - name: Ensure we authenticate the GH CLI
+        run: |
+          gh auth status || echo "Not authenticated"
+        shell: bash
+        env:
+          GH_TOKEN: ${{ steps.get-secrets.outputs.github-pat }}
+
       - name: Add mapping version
         run: |
           chmod +x scripts/add-mapping-version.sh
@@ -60,6 +67,7 @@ jobs:
           NEW_AGENT_VERSION: ${{ inputs.agent-version }}
           NEW_OSS_VERSION: ${{ inputs.oss-version }}
           DRY_RUN: ${{ inputs.dry-run }}
+          GH_TOKEN: ${{ steps.get-secrets.outputs.github-pat }}
 
       - name: Debug info
         run: |


### PR DESCRIPTION
Update the CI to ensure we use the appropriate token for authentication when running gh CLI commands in the version update scripts: https://github.com/FluentDo/documentation/actions/runs/17604942290/job/50013773423

<!-- greptile_comment -->

## Greptile Summary

Updated On: 2025-09-12 10:51:39 UTC

This PR fixes a GitHub CLI authentication issue in the FluentDo documentation repository's CI/CD pipeline. The changes address a failure in the `call-add-mapping-version.yaml` workflow where GitHub CLI commands were failing due to lack of proper authentication.

The workflow is a reusable GitHub Actions workflow that automates the process of adding new version mappings for the FluentDo agent. It already retrieves a GitHub Personal Access Token (PAT) from Google Cloud Platform Secret Manager and uses it for Git operations like checkout and PR creation. However, the `add-mapping-version.sh` script that gets executed internally calls `run-scans.sh`, which uses GitHub CLI (`gh api`) to fetch the latest agent release version from the GitHub API. Without the `GH_TOKEN` environment variable properly set, these API calls would fail or hit rate limits.

The fix adds two key improvements: first, a verification step that checks GitHub CLI authentication status for debugging purposes, and second, the addition of the `GH_TOKEN` environment variable to the script execution environment. This ensures that when the script makes GitHub API calls using the CLI, it has the necessary authentication credentials. The change integrates seamlessly with the existing authentication flow in the workflow, simply extending the scope of where the already-retrieved PAT is used.

## Important Files Changed

<details><summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| `.github/workflows/call-add-mapping-version.yaml` | 5/5 | Added GitHub CLI authentication verification step and GH_TOKEN environment variable to fix script execution failures |

</details>

## Confidence score: 5/5

- This PR is safe to merge with minimal risk as it only adds necessary authentication configuration
- Score reflects a straightforward fix that addresses a clear authentication issue without modifying core logic
- No files require special attention as the change is isolated and well-targeted

## Sequence Diagram
```mermaid
sequenceDiagram
    participant User
    participant GHA as "GitHub Actions"
    participant GCP as "GCP Secret Manager"
    participant SA as "Service Account"
    participant Repo as "Repository"
    participant CLI as "GH CLI"
    participant Tools as "External Tools"
    participant PR as "Pull Request"

    User->>GHA: "Trigger workflow with agent-version & oss-version"
    GHA->>GCP: "Authenticate with workload identity"
    GCP->>SA: "Validate service account"
    SA->>GHA: "Authentication successful"
    
    GHA->>GCP: "Get GitHub PAT secret"
    GCP->>GHA: "Return GitHub PAT token"
    
    GHA->>Repo: "Checkout repository with PAT"
    Repo->>GHA: "Repository checked out"
    
    GHA->>Tools: "Install grype and syft tools"
    Tools->>GHA: "Tools installed"
    
    GHA->>CLI: "Authenticate GH CLI with PAT"
    CLI->>GHA: "Authentication status confirmed"
    
    GHA->>GHA: "Execute add-mapping-version.sh script"
    
    alt if not dry-run
        GHA->>PR: "Create pull request with version mapping"
        PR->>GHA: "Return PR number and URL"
        GHA->>CLI: "Enable auto-merge on PR"
        CLI->>PR: "Auto-merge enabled"
    end
```

<!-- /greptile_comment -->