### PR TITLE
ci: ensure we authenticate with gh CLI

### DIFF
--- a/.github/workflows/cron-run-scan.yaml
+++ b/.github/workflows/cron-run-scan.yaml
@@ -52,9 +52,18 @@ jobs:
           curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin
         shell: bash
 
+      - name: Ensure we authenticate the GH CLI
+        run: |
+          gh auth status || echo "Not authenticated"
+        shell: bash
+        env:
+          GH_TOKEN: ${{ steps.get-secrets.outputs.github-pat }}
+
       - name: Run CVE scan
         run: ./scripts/security/run-scans.sh
         shell: bash
+        env:
+          GH_TOKEN: ${{ steps.get-secrets.outputs.github-pat }}
 
       - name: Create a PR with the update
         if: ${{ !inputs.dry-run }}


### PR DESCRIPTION
Ensure we have set up authentication for when we use the `gh` CLI in CI.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-09-25 09:05:15 UTC

<h3>Summary</h3>

Adds proper GitHub CLI authentication to the CVE scanning workflow by introducing a verification step and ensuring the `GH_TOKEN` environment variable is available to the CVE scanning script.

- Added authentication verification step using `gh auth status`
- Set `GH_TOKEN` environment variable for the CVE scanning script
- Enables the scanning script to use GitHub CLI commands that require authentication

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are straightforward authentication improvements that follow GitHub Actions best practices by properly setting environment variables and verifying authentication status
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | &nbsp;&nbsp;&nbsp;&nbsp; &nbsp;  Score &nbsp;&nbsp;&nbsp;&nbsp; &nbsp; | Overview |
|----------|-------|----------|
| .github/workflows/cron-run-scan.yaml | 5/5 | Added GitHub CLI authentication step and environment variable for CVE scanning script |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GHA as GitHub Actions
    participant GCP as GCP Secret Manager
    participant GHCLI as GitHub CLI
    participant Script as CVE Scan Script
    participant PR as Pull Request API

    GHA->>GCP: Authenticate with workload identity
    GCP->>GHA: Return service account credentials
    GHA->>GCP: Get GitHub PAT secret
    GCP->>GHA: Return GitHub PAT
    GHA->>GHCLI: Set GH_TOKEN environment variable
    GHCLI->>GHCLI: Authenticate with GitHub
    GHA->>Script: Execute run-scans.sh with GH_TOKEN
    Script->>GHCLI: Use gh commands for repository operations
    GHCLI->>PR: Create/manage pull requests via API
    PR->>GHA: Return PR details
```

<!-- /greptile_comment -->