### PR TITLE
ci: remove StepSecurity steps in workflows

### DIFF
--- a/.github/workflows/build-offline.yaml
+++ b/.github/workflows/build-offline.yaml
@@ -12,11 +12,6 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: Harden the runner
-        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
-        with:
-          egress-policy: ${{ vars.STEP_SECURITY_EGRESS_POLICY || 'audit' }}
-
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - run: scripts/generate-offline.sh

--- a/.github/workflows/call-add-mapping-version.yaml
+++ b/.github/workflows/call-add-mapping-version.yaml
@@ -27,11 +27,6 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     steps:
-      - name: Harden the runner
-        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
-        with:
-          egress-policy: ${{ vars.STEP_SECURITY_EGRESS_POLICY || 'audit' }}
-
       - name: Authenticate with GCP
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:

--- a/.github/workflows/cron-run-scan.yaml
+++ b/.github/workflows/cron-run-scan.yaml
@@ -22,11 +22,6 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     steps:
-      - name: Harden the runner
-        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
-        with:
-          egress-policy: ${{ vars.STEP_SECURITY_EGRESS_POLICY || 'audit' }}
-
       - name: Authenticate with GCP
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,13 +1,6 @@
-# Dependency Review Action
-#
-# This Action will scan dependency manifest files that change as part of a Pull Request,
-# surfacing known-vulnerable versions of the packages declared or updated in the PR.
-# Once installed, if the workflow run is marked as required,
-# PRs introducing known-vulnerable packages will be blocked from merging.
-#
-# Source repository: https://github.com/actions/dependency-review-action
 name: 'Dependency Review'
-on: [pull_request]
+on: 
+  pull_request:
 
 permissions:
   contents: read
@@ -16,11 +9,6 @@ jobs:
   dependency-review:
     runs-on: ubuntu-latest
     steps:
-      - name: Harden the runner 
-        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
-        with:
-          egress-policy: ${{ vars.STEP_SECURITY_EGRESS_POLICY || 'audit' }}
-
       - name: 'Checkout Repository'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: 'Dependency Review'

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -12,9 +12,6 @@ on:
 permissions:
   contents: read
 
-env:
-  # Set once from repo variable or override here for testing
-  STEP_SECURITY_EGRESS_POLICY: ${{ vars.STEP_SECURITY_EGRESS_POLICY || 'audit' }}
 jobs:
   shellcheck-pr:
     permissions:
@@ -23,11 +20,6 @@ jobs:
     runs-on: ubuntu-latest
     name: PR - Shellcheck
     steps:
-      - name: Harden the runner
-        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
-        with:
-          egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
-
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: reviewdog/action-shellcheck@4c07458293ac342d477251099501a718ae5ef86e # v1.32.0
         with:
@@ -44,11 +36,6 @@ jobs:
     runs-on: ubuntu-latest
     name: PR - Actionlint
     steps:
-      - name: Harden the runner
-        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
-        with:
-          egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
-
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - run: |
           echo "::add-matcher::.github/actionlint-matcher.json"
@@ -60,11 +47,6 @@ jobs:
     runs-on: ubuntu-latest
     name: PR - Check Orphaned Documentation
     steps:
-      - name: Harden the runner
-        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
-        with:
-          egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
-
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Check for orphaned markdown files
         run: bash ./scripts/check-orphaned-docs.sh
@@ -78,11 +60,6 @@ jobs:
       # For ReviewDog to post comments to the PR
       pull-requests: write
     steps:
-      - name: Harden the runner
-        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
-        with:
-          egress-policy: ${{ env.STEP_SECURITY_EGRESS_POLICY }}
-
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: suzuki-shunsuke/pinact-action@cf51507d80d4d6522a07348e3d58790290eaf0b6  # v2.0.0
         with:

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -35,11 +35,6 @@ jobs:
       checks: read
 
     steps:
-      - name: Harden the runner
-        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
-        with:
-          egress-policy: ${{ vars.STEP_SECURITY_EGRESS_POLICY || 'audit' }}
-
       - name: "Checkout code"
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:


### PR DESCRIPTION
Private repositories require Enterprise plan so removing to ensure CI continues after trial expires.